### PR TITLE
Add client system for adding HUD

### DIFF
--- a/assets/skins/healthDefault.skin
+++ b/assets/skins/healthDefault.skin
@@ -1,0 +1,26 @@
+{
+    "inherit": "default",
+    "elements": {
+        "UIIconBar": {
+            "parts": {
+                "icon": {
+                    "fixed-width": 16,
+                    "fixed-height": 16
+                }
+            }
+        }
+    },
+    "families": {
+        "healthBar": {
+            "elements": {
+                "UIIconBar": {
+                    "parts": {
+                        "icon": {
+                            "background": "engine:icons#darkHeartOutline"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assets/ui/hud/healthHud.ui
+++ b/assets/ui/hud/healthHud.ui
@@ -1,0 +1,27 @@
+{
+    "type": "HealthHud",
+    "skin": "healthDefault",
+    "contents": {
+        "type": "relativeLayout",
+        "contents": [
+            {
+                "type": "UIIconBar",
+                "id": "healthBar",
+                "family": "healthBar",
+                "icon": "engine:icons#redHeart",
+                "halfIconMode": "split",
+                "spacing": 2,
+                "maxIcons": 10,
+                "layoutInfo": {
+                    "use-content-width": true,
+                    "use-content-height": true,
+                    "position-horizontal-center": {},
+                    "position-bottom": {
+                        "target": "BOTTOM",
+                        "offset": 60
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/main/java/org/terasology/logic/health/HealthClientSystem.java
+++ b/src/main/java/org/terasology/logic/health/HealthClientSystem.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.health;
+
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+
+@RegisterSystem(RegisterMode.CLIENT)
+public class HealthClientSystem extends BaseComponentSystem {
+
+    @In
+    private NUIManager nuiManager;
+
+    @Override
+    public void initialise() {
+        nuiManager.getHUD().addHUDElement("healthHud");
+    }
+}

--- a/src/main/java/org/terasology/rendering/nui/layers/hud/HealthHud.java
+++ b/src/main/java/org/terasology/rendering/nui/layers/hud/HealthHud.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.layers.hud;
+
+import org.terasology.logic.health.HealthComponent;
+import org.terasology.logic.players.LocalPlayer;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
+import org.terasology.rendering.nui.widgets.UIIconBar;
+
+public class HealthHud extends CoreHudWidget {
+
+    @In
+    private LocalPlayer localPlayer;
+
+    @Override
+    public void initialise() {
+        UIIconBar healthBar = find("healthBar", UIIconBar.class);
+        healthBar.bindValue(new ReadOnlyBinding<Float>() {
+            @Override
+            public Float get() {
+                HealthComponent healthComponent = localPlayer.getCharacterEntity().getComponent(HealthComponent.class);
+                if (healthComponent != null) {
+                    return (float) healthComponent.currentHealth;
+                }
+                return 0f;
+            }
+        });
+        healthBar.bindMaxValue(new ReadOnlyBinding<Float>() {
+            @Override
+            public Float get() {
+                HealthComponent healthComponent = localPlayer.getCharacterEntity().getComponent(HealthComponent.class);
+                if (healthComponent != null) {
+                    return (float) healthComponent.maxHealth;
+                }
+                return 0f;
+            }
+        });
+    }
+}


### PR DESCRIPTION
Adds healthHud.ui and corresponding client system for adding the HUD to clients.

How to test:
1. Create a new game with `BuilderSampleGameplay` template and activate Health in advanced settings.
2. See that the Health HUD is displayed. 
3. Execute console command `damage 10`, see that the health is reduced in HUD