### PR TITLE
Add Regenerate Logic

### DIFF
--- a/src/main/java/org/terasology/logic/health/event/BeforeRegenEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/BeforeRegenEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.health.event;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.AbstractConsumableValueModifiableEvent;
+
+/**
+ * This event is sent to an entity to allow modification and cancellation of regen.
+ *
+ * Modifications are accumulated as modifiers (additions), multipliers and postModifiers (additions after multipliers).
+ */
+public class BeforeRegenEvent extends AbstractConsumableValueModifiableEvent {
+    /** The entity which is being regenerated. */
+    private EntityRef entity;
+
+    /**
+     * Constructor to create a new BeforeRegenEvent.
+     *
+     * @param amount    The amount by which the entity is regenerated.
+     * @param entity    The entity which is being regenerated.
+     */
+    public BeforeRegenEvent(int amount, EntityRef entity) {
+        super(amount);
+        this.entity = entity;
+    }
+
+    /**
+     * Method to get the EntityRef of entity being regenerated.
+     * @return Entity being regenerated.
+     */
+    public EntityRef getEntity() {
+        return entity;
+    }
+
+}

--- a/src/main/java/org/terasology/logic/health/event/OnRegenedEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/OnRegenedEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.health.event;
+
+import org.terasology.entitySystem.entity.EntityRef;
+
+public class OnRegenedEvent extends HealthChangedEvent {
+    private int amount;
+
+    public OnRegenedEvent (int amount, EntityRef instigator) {
+        super(instigator, amount);
+        this.amount = amount;
+    }
+
+    public int getRegenAmount() {
+        return amount;
+    }
+
+}

--- a/src/main/java/org/terasology/logic/health/event/RegenerateEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/RegenerateEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.health.event;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+
+/**
+ * The event sent to regenerate entity. Starting point of Regeneration cycle.
+ */
+public class RegenerateEvent implements Event {
+    /** The amount of health points being regenerated */
+    private int amount;
+    /** The entity which is being regenerated. */
+    private EntityRef entity;
+
+
+    /**
+     * Constructor for event providing only amount.
+     * @param amount    The amount of regeneration.
+     */
+    public RegenerateEvent(int amount) {
+        this(amount, EntityRef.NULL);
+    }
+
+    /**
+     * Constructor for event, with amount and entity specified.
+     * @param amount            The amount of regeneration.
+     * @param restoreEntity     The entity which is being regenerated.
+     */
+    public RegenerateEvent(int amount, EntityRef restoreEntity) {
+        this.amount = amount;
+        this.entity = restoreEntity;
+    }
+
+    /**
+     * Method to get the amount of regeneration.
+     * @return amount of regeneration.
+     */
+    public int getAmount() {
+        return amount;
+    }
+
+    /**
+     * @return the entity whose health is getting regenerated.
+     */
+    public EntityRef getEntity() {
+        return entity;
+    }
+}

--- a/src/test/java/org/terasology/logic/health/RegenTest.java
+++ b/src/test/java/org/terasology/logic/health/RegenTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.health;
+
+import com.google.api.client.util.Sets;
+import org.junit.Before;
+import org.junit.Test;
+import org.terasology.engine.Time;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.health.event.BeforeRegenEvent;
+import org.terasology.logic.health.event.DoDamageEvent;
+import org.terasology.logic.players.PlayerCharacterComponent;
+import org.terasology.moduletestingenvironment.ModuleTestingEnvironment;
+import org.terasology.moduletestingenvironment.TestEventReceiver;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RegenTest extends ModuleTestingEnvironment {
+
+    private EntityManager entityManager;
+    private Time time;
+
+    @Override
+    public Set<String> getDependencies() {
+        Set<String> modules = Sets.newHashSet();
+        modules.add("Health");
+        return modules;
+    }
+
+    @Before
+    public void initialize() {
+        entityManager = getHostContext().get(EntityManager.class);
+        time = getHostContext().get(Time.class);
+    }
+
+    @Test
+    public void regenTest() {
+        HealthComponent healthComponent = new HealthComponent();
+        healthComponent.currentHealth = 100;
+        healthComponent.maxHealth = 100;
+        healthComponent.waitBeforeRegen = 1;
+        healthComponent.regenRate = 1;
+
+        final EntityRef player = entityManager.create();
+        player.addComponent(new PlayerCharacterComponent());
+        player.addComponent(healthComponent);
+
+        TestEventReceiver<BeforeRegenEvent> receiver = new TestEventReceiver<>(getHostContext(), BeforeRegenEvent.class);
+        List<BeforeRegenEvent> list = receiver.getEvents();
+        assertTrue(list.isEmpty());
+
+        player.send(new DoDamageEvent(5));
+        assertEquals(healthComponent.currentHealth, 95);
+        float currentTick = time.getGameTime();
+        // 1 sec wait before regen, 5 secs for regen, 0.1 sec for padding.
+        float tick = time.getGameTime() + 6 + 0.100f;
+        int heal = 0;
+        runWhile(()-> time.getGameTime() <= tick );
+        assertEquals(5, list.size());
+        assertEquals(healthComponent.currentHealth, 100);
+    }
+}


### PR DESCRIPTION
Currently can't be tested directly, as only underlying events are changed.

How to test that regen still works:
1. Add `player.prefab` in Health/deltas/engine/prefabs/player from deltas in Core module.
2. Check out [PR#3677](https://github.com/MovingBlocks/Terasology/pull/3677) branch in Terasology repo.
3. Activate Health module in a new game, execute console command `damage 30`. 
4. See that regen starts after 10 secs and full health is attained at 20 secs after the damage is inflicted.