### PR TITLE
Update ActivateRegenEvent to have float value

### DIFF
--- a/src/main/java/org/terasology/logic/health/event/ActivateRegenEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/ActivateRegenEvent.java
@@ -21,7 +21,7 @@ import static org.terasology.logic.health.RegenAuthoritySystem.BASE_REGEN;
 
 public class ActivateRegenEvent implements Event {
     public String id;
-    public int value;
+    public float value;
     public float endTime;
 
     public ActivateRegenEvent() {
@@ -29,7 +29,7 @@ public class ActivateRegenEvent implements Event {
         endTime = 0;
     }
 
-    public ActivateRegenEvent(String id, int value, float endTime) {
+    public ActivateRegenEvent(String id, float value, float endTime) {
         this.id = id;
         this.value = value;
         this.endTime = endTime;


### PR DESCRIPTION
No major code change. `RegenComponent` uses float to save values, so the activate event should also have a float value, instead of int.