### PR TITLE
Height extras

### DIFF
--- a/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
@@ -94,6 +94,13 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         event.consume();
     }
 
+    private float jumpOfCharacter(EntityRef entity){
+        HealthComponent health = entity.getComponent(HealthComponent.class);
+        CharacterMovementComponent charComp = entity.getComponent(CharacterMovementComponent.class);
+        return charComp.getJumpSpeed();
+
+    }
+
     private void doDamage(EntityRef entity, int damageAmount, Prefab damageType, EntityRef instigator, EntityRef directCause) {
         HealthComponent health = entity.getComponent(HealthComponent.class);
         CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);
@@ -180,11 +187,15 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
      * @param event VerticalCollisionEvent sent when falling speed threshold is crossed.
      * @param entity The entity which is damaged due to falling.
      */
+
+
+
     @ReceiveEvent
     public void onLand(VerticalCollisionEvent event, EntityRef entity, HealthComponent health) {
         float speed = Math.abs(event.getVelocity().y);
+        float jump = jumpOfCharacter(entity);
 
-        highSpeedDamage(speed, entity, health.fallingDamageSpeedThreshold, health.excessSpeedDamageMultiplier);
+        highSpeedDamage(speed, entity, health.fallingDamageSpeedThreshold * jump, health.excessSpeedDamageMultiplier);
     }
 
     /**

--- a/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
@@ -95,7 +95,6 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
     }
 
     private float heightOfCharacter(EntityRef entity){
-        HealthComponent health = entity.getComponent(HealthComponent.class);
         CharacterMovementComponent charComp = entity.getComponent(CharacterMovementComponent.class);
         return charComp.getPlayerHeight();
 

--- a/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
@@ -96,7 +96,7 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
 
     private float heightOfCharacter(EntityRef entity) {
         CharacterMovementComponent charComp = entity.getComponent(CharacterMovementComponent.class);
-        return charComp.height;
+        return charComp.getPlayerHeight();
 
     }
 

--- a/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
@@ -203,7 +203,7 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
     /**
      * Inflicts damage to entity if horizontalDamageSpeedThreshold is breached.
      *
-     * @param event  HorizontalCollisionEvent sent when "falling horizontally".
+     * @param event HorizontalCollisionEvent sent when "falling horizontally".
      * @param entity Entity which is damaged on "horizontal fall".
      */
     @ReceiveEvent

--- a/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
@@ -94,10 +94,10 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         event.consume();
     }
 
-    private float jumpOfCharacter(EntityRef entity){
+    private float heightOfCharacter(EntityRef entity){
         HealthComponent health = entity.getComponent(HealthComponent.class);
         CharacterMovementComponent charComp = entity.getComponent(CharacterMovementComponent.class);
-        return charComp.getJumpSpeed();
+        return charComp.getPlayerHeight();
 
     }
 
@@ -193,9 +193,9 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
     @ReceiveEvent
     public void onLand(VerticalCollisionEvent event, EntityRef entity, HealthComponent health) {
         float speed = Math.abs(event.getVelocity().y);
-        float jump = jumpOfCharacter(entity);
+        float height = heightOfCharacter(entity);
 
-        highSpeedDamage(speed, entity, health.fallingDamageSpeedThreshold * jump, health.excessSpeedDamageMultiplier);
+        highSpeedDamage(speed, entity, health.fallingDamageSpeedThreshold * height/ 1.6f, health.excessSpeedDamageMultiplier);
     }
 
     /**
@@ -209,8 +209,9 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         Vector3f vel = new Vector3f(event.getVelocity());
         vel.y = 0;
         float speed = vel.length();
+        float height = heightOfCharacter(entity);
 
-        highSpeedDamage(speed, entity, health.horizontalDamageSpeedThreshold, health.excessSpeedDamageMultiplier);
+        highSpeedDamage(speed, entity, height < 30 ? health.horizontalDamageSpeedThreshold : 10000, health.excessSpeedDamageMultiplier);
     }
 
     private void highSpeedDamage(float speed, EntityRef entity, float threshold, float damageMultiplier) {

--- a/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
@@ -94,12 +94,6 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         event.consume();
     }
 
-    private float heightOfCharacter(EntityRef entity) {
-        CharacterMovementComponent charComp = entity.getComponent(CharacterMovementComponent.class);
-        return charComp.getPlayerHeight();
-
-    }
-
     private void doDamage(EntityRef entity, int damageAmount, Prefab damageType, EntityRef instigator, EntityRef directCause) {
         HealthComponent health = entity.getComponent(HealthComponent.class);
         CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);
@@ -192,7 +186,8 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
     @ReceiveEvent
     public void onLand(VerticalCollisionEvent event, EntityRef entity, HealthComponent health) {
         float speed = Math.abs(event.getVelocity().y);
-        float height = heightOfCharacter(entity);
+        CharacterMovementComponent charComp = entity.getComponent(CharacterMovementComponent.class);
+        float height = charComp.height;
 
         highSpeedDamage(speed, entity, health.fallingDamageSpeedThreshold * height / 1.6f, health.excessSpeedDamageMultiplier);
     }
@@ -208,7 +203,9 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         Vector3f vel = new Vector3f(event.getVelocity());
         vel.y = 0;
         float speed = vel.length();
-        float height = heightOfCharacter(entity);
+        CharacterMovementComponent charComp = entity.getComponent(CharacterMovementComponent.class);
+        float height = charComp.height;
+        
         health.horizontalDamageSpeedThreshold = 14.1f + 0.73f * height + 0.02f * height * height;
 
         highSpeedDamage(speed, entity, health.horizontalDamageSpeedThreshold, health.excessSpeedDamageMultiplier);

--- a/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
@@ -94,9 +94,9 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         event.consume();
     }
 
-    private float heightOfCharacter(EntityRef entity){
+    private float heightOfCharacter(EntityRef entity) {
         CharacterMovementComponent charComp = entity.getComponent(CharacterMovementComponent.class);
-        return charComp.getPlayerHeight();
+        return charComp.height;
 
     }
 
@@ -194,7 +194,7 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         float speed = Math.abs(event.getVelocity().y);
         float height = heightOfCharacter(entity);
 
-        highSpeedDamage(speed, entity, health.fallingDamageSpeedThreshold * height/ 1.6f, health.excessSpeedDamageMultiplier);
+        highSpeedDamage(speed, entity, health.fallingDamageSpeedThreshold * height / 1.6f, health.excessSpeedDamageMultiplier);
     }
 
     /**
@@ -209,8 +209,9 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         vel.y = 0;
         float speed = vel.length();
         float height = heightOfCharacter(entity);
+        health.horizontalDamageSpeedThreshold = 14.1f + 0.73f * height + 0.02f * height * height;
 
-        highSpeedDamage(speed, entity, height < 30 ? health.horizontalDamageSpeedThreshold : 10000, health.excessSpeedDamageMultiplier);
+        highSpeedDamage(speed, entity, health.horizontalDamageSpeedThreshold, health.excessSpeedDamageMultiplier);
     }
 
     private void highSpeedDamage(float speed, EntityRef entity, float threshold, float damageMultiplier) {

--- a/src/main/java/org/terasology/logic/health/HealthComponent.java
+++ b/src/main/java/org/terasology/logic/health/HealthComponent.java
@@ -16,6 +16,11 @@
 package org.terasology.logic.health;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.characters.CharacterMovementComponent;
+import org.terasology.logic.characters.GazeMountPointComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.network.ClientComponent;
 import org.terasology.network.Replicate;
 import org.terasology.rendering.nui.properties.TextField;
 
@@ -28,6 +33,9 @@ public class HealthComponent implements Component {
     /** Maximum allowed health, capped to this if exceeding this value. */
     @Replicate
     public int maxHealth = 20;
+
+
+
 
     /** Falling speed threshold above which damage is inflicted to entity. */
     @Replicate

--- a/src/main/java/org/terasology/logic/health/HealthComponent.java
+++ b/src/main/java/org/terasology/logic/health/HealthComponent.java
@@ -16,11 +16,6 @@
 package org.terasology.logic.health;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.characters.CharacterMovementComponent;
-import org.terasology.logic.characters.GazeMountPointComponent;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.network.ClientComponent;
 import org.terasology.network.Replicate;
 import org.terasology.rendering.nui.properties.TextField;
 
@@ -33,9 +28,6 @@ public class HealthComponent implements Component {
     /** Maximum allowed health, capped to this if exceeding this value. */
     @Replicate
     public int maxHealth = 20;
-
-
-
 
     /** Falling speed threshold above which damage is inflicted to entity. */
     @Replicate


### PR DESCRIPTION
## Contains
An attempt to fix a sub issue of https://github.com/MovingBlocks/Terasology/issues/2535 along with https://github.com/MovingBlocks/Terasology/pull/3841
The vertical damage speed threshold varies with the player's height. I noticed that at  heights greater than 30,the player took damage on horizontal collision.Hence, i made the character immune to horizontal damage at those heights.

- [x] Increase/Decrease damage from fall. (30m giant should not die of a 15m fall). Define function/proportionality constant same as above.
## How to test

Change the player's height and you will see that the it won't lose any health on jumping.
