### PR TITLE
feat: move logic from regen component to system

### DIFF
--- a/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
@@ -32,6 +32,7 @@ import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.health.event.ActivateRegenEvent;
 import org.terasology.logic.health.event.DeactivateRegenEvent;
 import org.terasology.logic.health.event.OnFullyHealedEvent;
+import org.terasology.math.TeraMath;
 import org.terasology.registry.In;
 
 import java.util.HashMap;
@@ -111,7 +112,7 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
                     regenEntity.removeComponent(RegenComponent.class);
                 } else {
                     regenEntity.saveComponent(regen);
-                    regenSortedByTime.put(regen.findSoonestEndTime(), regenEntity);
+                    regenSortedByTime.put(findSoonestEndTime(regen), regenEntity);
                 }
             }
         });
@@ -126,11 +127,11 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
             RegenComponent regen = entity.getComponent(RegenComponent.class);
             HealthComponent health = entity.getComponent(HealthComponent.class);
             if (health != null && health.nextRegenTick < currentTime) {
-                health.currentHealth += regen.getRegenValue();
+                health.currentHealth += getRegenValue(regen);
                 health.nextRegenTick = currentTime + 1000;
                 if (health.currentHealth >= health.maxHealth) {
                     regenToBeRemoved.put(entity, regen.soonestEndTime);
-                    if (regen.hasBaseRegenOnly() || regen.regenValue.isEmpty()) {
+                    if (hasBaseRegenOnly(regen) || regen.regenValue.isEmpty()) {
                         entity.removeComponent(RegenComponent.class);
                     }
                     entity.send(new OnFullyHealedEvent(entity));
@@ -163,7 +164,7 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
         for (String id: toBeRemoved) {
             regen.regenValue.remove(id);
         }
-        regen.soonestEndTime = regen.findSoonestEndTime();
+        regen.soonestEndTime = findSoonestEndTime(regen);
     }
 
 
@@ -192,11 +193,11 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
                                      HealthComponent health) {
         if (event.id.equals(BASE_REGEN)) {
             // setting endTime to -1 because natural regen happens till entity fully regenerates
-            regen.addRegen(BASE_REGEN, health.regenRate, -1);
-            regen.addRegen(WAIT, -health.regenRate,
-                    time.getGameTimeInMs() + (long) (health.waitBeforeRegen * 1000));
+            addRegen(BASE_REGEN, health.regenRate, -1, regen);
+            addRegen(WAIT, -health.regenRate,
+                    time.getGameTimeInMs() + (long) (health.waitBeforeRegen * 1000), regen);
         } else {
-            regen.addRegen(event.id, event.value, time.getGameTimeInMs() + (long) (event.endTime * 1000));
+            addRegen(event.id, event.value, time.getGameTimeInMs() + (long) (event.endTime * 1000), regen);
         }
     }
 
@@ -216,13 +217,63 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
         if (event.id.equals(ALL_REGEN)) {
             entity.removeComponent(RegenComponent.class);
         } else {
-            regen.removeRegen(event.id);
+            removeRegen(event.id, regen);
             if (event.id.equals(BASE_REGEN)) {
-                regen.removeRegen(WAIT);
+                removeRegen(WAIT, regen);
             }
             if (!regen.regenValue.isEmpty()) {
                 regenSortedByTime.put(regen.soonestEndTime, entity);
             }
         }
+    }
+
+    private Long findSoonestEndTime(RegenComponent regen) {
+        Long endTime = 0L;
+        Iterator<Long> iterator = regen.regenEndTime.keySet().iterator();
+        while (iterator.hasNext()) {
+            endTime = iterator.next();
+            if (endTime > 0) {
+                return endTime;
+            }
+        }
+        return endTime;
+    }
+
+    private void addRegen(String id, float value, long endTime, RegenComponent regen) {
+        if (value != 0) {
+            regen.regenValue.put(id, value);
+            regen.regenEndTime.put(endTime, id);
+            if (endTime > 0) {
+                regen.soonestEndTime = Math.min(regen.soonestEndTime, endTime);
+            }
+        }
+    }
+
+    private void removeRegen(String id, RegenComponent regen) {
+        Long removeKey = 0L;
+        for (Long key : regen.regenEndTime.keySet()) {
+            for (String value : regen.regenEndTime.get(key)) {
+                if (id.equals(value)) {
+                    removeKey = key;
+                    break;
+                }
+            }
+        }
+        regen.regenEndTime.remove(removeKey, id);
+        regen.regenValue.remove(id);
+    }
+
+    private int getRegenValue(RegenComponent regen) {
+        float totalValue = regen.remainder;
+        for (float value : regen.regenValue.values()) {
+            totalValue += value;
+        }
+        totalValue = Math.max(0, totalValue);
+        regen.remainder = totalValue % 1;
+        return TeraMath.floorToInt(totalValue);
+    }
+
+    public boolean hasBaseRegenOnly(RegenComponent regen) {
+        return (regen.regenValue.size() == 1) && (regen.regenValue.containsKey(BASE_REGEN));
     }
 }

--- a/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.logic.health;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
@@ -263,7 +264,8 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
         regen.regenValue.remove(id);
     }
 
-    private int getRegenValue(RegenComponent regen) {
+    @VisibleForTesting
+    int getRegenValue(RegenComponent regen) {
         float totalValue = regen.remainder;
         for (float value : regen.regenValue.values()) {
             totalValue += value;

--- a/src/main/java/org/terasology/logic/health/RegenComponent.java
+++ b/src/main/java/org/terasology/logic/health/RegenComponent.java
@@ -19,11 +19,9 @@ import com.google.common.collect.Ordering;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
 import org.terasology.entitySystem.Component;
-import org.terasology.math.TeraMath;
 import org.terasology.network.Replicate;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import static org.terasology.logic.health.RegenAuthoritySystem.BASE_REGEN;
@@ -38,54 +36,4 @@ public class RegenComponent implements Component {
             Ordering.arbitrary());
     @Replicate
     public float remainder;
-
-    public Long findSoonestEndTime() {
-        Long endTime = 0L;
-        Iterator<Long> iterator = regenEndTime.keySet().iterator();
-        while (iterator.hasNext()) {
-            endTime = iterator.next();
-            if (endTime > 0) {
-                return endTime;
-            }
-        }
-        return endTime;
-    }
-
-    public void addRegen(String id, float value, long endTime) {
-        if (value != 0) {
-            regenValue.put(id, value);
-            regenEndTime.put(endTime, id);
-            if (endTime > 0) {
-                soonestEndTime = Math.min(soonestEndTime, endTime);
-            }
-        }
-    }
-
-    public void removeRegen(String id) {
-        Long removeKey = 0L;
-        for (Long key : regenEndTime.keySet()) {
-            for (String value : regenEndTime.get(key)) {
-                if (id.equals(value)) {
-                    removeKey = key;
-                    break;
-                }
-            }
-        }
-        regenEndTime.remove(removeKey, id);
-        regenValue.remove(id);
-    }
-
-    public int getRegenValue() {
-        float totalValue = remainder;
-        for (float value : regenValue.values()) {
-            totalValue += value;
-        }
-        totalValue = Math.max(0, totalValue);
-        remainder = totalValue % 1;
-        return TeraMath.floorToInt(totalValue);
-    }
-
-    public boolean hasBaseRegenOnly() {
-        return (regenValue.size() == 1) && (regenValue.containsKey(BASE_REGEN));
-    }
 }

--- a/src/test/java/org/terasology/logic/health/RegenTest.java
+++ b/src/test/java/org/terasology/logic/health/RegenTest.java
@@ -88,13 +88,14 @@ public class RegenTest extends ModuleTestingEnvironment {
         player.send(new ActivateRegenEvent("Potion#2", 2, 10));
 
         RegenComponent regen = player.getComponent(RegenComponent.class);
-        assertEquals(7, regen.getRegenValue());
+        RegenAuthoritySystem system = new RegenAuthoritySystem();
+        assertEquals(7, system.getRegenValue(regen));
 
         float tick = time.getGameTime() + 6 + 0.200f;
         runWhile(()-> time.getGameTime() <= tick);
 
         regen = player.getComponent(RegenComponent.class);
-        assertEquals(2, regen.getRegenValue());
+        assertEquals(2, system.getRegenValue(regen));
     }
 
     @Test


### PR DESCRIPTION
### Contains

Fixed #20 to make the RegenComponent fit better with ECS by removing logic in the RegenComponent and moving it to the RegenAuthoritySystem.

### How to test

Take some damage via fall damage or using the 'damage <amount>' command in the console and wait for your health to regenerate!