### PR TITLE
fix: `ModuleTestingEnvironment` dependency

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -6,7 +6,7 @@
     "displayName" : "Health",
     "description" : "This module provides basic implementation of Health",
     "dependencies" : [
-        { "id": "ModuleTestingEnvironment", "minVersion": "0.2.0", "optional":true },
+        { "id": "ModuleTestingEnvironment", "minVersion": "0.2.0", "optional": true },
         { "id": "CoreAssets", "minVersion": "2.0.1" }
     ],
     "serverSideOnly" : false,

--- a/module.txt
+++ b/module.txt
@@ -6,7 +6,7 @@
     "displayName" : "Health",
     "description" : "This module provides basic implementation of Health",
     "dependencies" : [
-        { "id": "ModuleTestingEnvironment", "minVersion": "0.1.0", "optional":true },
+        { "id": "ModuleTestingEnvironment", "minVersion": "0.2.0", "optional":true },
         { "id": "CoreAssets", "minVersion": "2.0.1" }
     ],
     "serverSideOnly" : false,


### PR DESCRIPTION
- pre-release minor versions seem to be treated like real-release major versions wrt inclusion/exclusion