### PR TITLE
doc: Improve JavaDoc for ActivateRegenEvent

### DIFF
--- a/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
@@ -1,26 +1,11 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.logic.health;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -44,6 +29,9 @@ import java.util.Map;
 
 /**
  * This system handles the natural regeneration of entities with HealthComponent.
+ * <p>
+ * Regeneration is applied once every second (every 1000ms) per {@link RegenComponent}. The active components are
+ * checked five times per second (every 200ms) whether they are due for application.
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateSubscriberSystem {
@@ -162,7 +150,7 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
                 break;
             }
         }
-        for (String id: toBeRemoved) {
+        for (String id : toBeRemoved) {
             regen.regenValue.remove(id);
         }
         regen.soonestEndTime = findSoonestEndTime(regen);

--- a/src/main/java/org/terasology/logic/health/event/ActivateRegenEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/ActivateRegenEvent.java
@@ -57,6 +57,14 @@ public class ActivateRegenEvent implements Event {
      * <p>
      * The {@code endTime} denotes after how many seconds the regeneration effect phases out. Once the time span is
      * passed the effect will be removed from the entity.
+     * <p>
+     * For instance, the following constructor call could belong to a small healing potion which restores 8 health
+     * points every second over a duration of 5 seconds (e.g., healing 40 health points).
+     * <pre>
+     * {@code
+     * new ActivateRegenEvent("potions:smallHealingPotion", 8, 5);
+     * }
+     * </pre>
      *
      * @param id identifier for the cause of this effect
      * @param value additional health generation amount per tick

--- a/src/main/java/org/terasology/logic/health/event/ActivateRegenEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/ActivateRegenEvent.java
@@ -1,34 +1,67 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.logic.health.event;
 
 import org.terasology.entitySystem.event.Event;
 
 import static org.terasology.logic.health.RegenAuthoritySystem.BASE_REGEN;
 
+/**
+ * Send this event to active regeneration of health points for an entity.
+ * <p>
+ * The targeted entity must have a {@link org.terasology.logic.health.HealthComponent} for this event to have an
+ * effect.
+ * <p>
+ * The {@link org.terasology.logic.health.RegenAuthoritySystem} manages regeneration effects and updates affected
+ * components every "tick". A tick currently occurs once per second.
+ *
+ * @see org.terasology.logic.health.RegenAuthoritySystem
+ * @see org.terasology.logic.health.RegenComponent
+ * @see org.terasology.logic.health.HealthComponent
+ */
 public class ActivateRegenEvent implements Event {
+    /**
+     * Identifier for the cause of this regeneration effect activation.
+     */
     public String id;
+    /**
+     * Amount of additional health points per tick.
+     */
     public float value;
+    /**
+     * Effect duration in seconds.
+     */
     public float endTime;
 
+    /**
+     * Active base regeneration for the target entity.
+     * <p>
+     * Base regeneration (or "natural regeneration") is active until the entity is back at full health. The regeneration
+     * value is defined by {@link org.terasology.logic.health.HealthComponent#regenRate}.
+     */
     public ActivateRegenEvent() {
         id = BASE_REGEN;
+        //TODO(skaldarnar): Why do we explicitly set the end time to 0 but don't set the value? The regeneration system
+        //                  will replace this value by -1 to model indefinite duration.
         endTime = 0;
     }
 
+    /**
+     * Activate additional regeneration for the target entity.
+     * <p>
+     * The {@code id} is intended to uniquely identify the reason for this regeneration effect. For instance, it can
+     * denote that regeneration was trigger by a potion, caused by a spell, or any other condition.
+     * <p>
+     * The {@code value} denotes the additional amount of health points regenerated with each regeneration tick while
+     * this effect is active.
+     * <p>
+     * The {@code endTime} denotes after how many seconds the regeneration effect phases out. Once the time span is
+     * passed the effect will be removed from the entity.
+     *
+     * @param id identifier for the cause of this effect
+     * @param value additional health generation amount per tick
+     * @param endTime the effect duration in seconds
+     */
     public ActivateRegenEvent(String id, float value, float endTime) {
         this.id = id;
         this.value = value;


### PR DESCRIPTION
Improve JavaDoc for `ActiveRegenEvent` by making some internal assumptions and semantics explicit.

For instance, the `endTime`  of the activate event is _not_ a time stamp when the effect should end (in world time) but is interpreted as the **duration** the effect should stay active in seconds. I think it is important to state the unit (seconds) that the value is assumed to be in, as well as  what it is actually used for. 

Same holds for the `id` and the `value`.
