### PR TITLE
test: fix failing tests by increasing timeout

### DIFF
--- a/assets/prefabs/damageTypes/maxHealthReductionDamage.prefab
+++ b/assets/prefabs/damageTypes/maxHealthReductionDamage.prefab
@@ -1,0 +1,5 @@
+{
+    "DisplayName": {
+        "name": "MaxHealthReduction"
+    }
+}

--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "Health",
-    "version" : "1.0.1",
+    "version" : "1.0.2",
     "isReleaseManaged": true,
     "author" : "The Terasology Foundation",
     "displayName" : "Health",

--- a/module.txt
+++ b/module.txt
@@ -6,7 +6,7 @@
     "displayName" : "Health",
     "description" : "This module provides basic implementation of Health",
     "dependencies" : [
-        { "id": "ModuleTestingEnvironment", "minVersion": "0.1.0", "optional":true },
+        { "id": "ModuleTestingEnvironment", "minVersion": "0.2.0", "optional": true },
         { "id": "CoreAssets", "minVersion": "2.0.1" }
     ],
     "serverSideOnly" : false,

--- a/src/main/java/org/terasology/logic/health/BlockDamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/BlockDamageAuthoritySystem.java
@@ -30,6 +30,7 @@ import org.terasology.logic.health.event.BeforeDamagedEvent;
 import org.terasology.logic.health.event.OnDamagedEvent;
 import org.terasology.logic.health.event.OnFullyHealedEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
@@ -170,7 +171,7 @@ public class BlockDamageAuthoritySystem extends BaseComponentSystem {
             spriteComponent.texture = terrainTexture.get();
             spriteComponent.textureSize.set(spriteSize, spriteSize);
 
-            final List<Vector2f> offsets = computeOffsets(blockAppearance, particleScale);
+            final List<org.joml.Vector2f> offsets = computeOffsets(blockAppearance, particleScale);
 
             TextureOffsetGeneratorComponent textureOffsetGeneratorComponent = builder.getComponent(TextureOffsetGeneratorComponent.class);
             textureOffsetGeneratorComponent.validOffsets.addAll(offsets);
@@ -187,7 +188,7 @@ public class BlockDamageAuthoritySystem extends BaseComponentSystem {
      *
      * @return a list of random offsets sampled from all block parts
      */
-    private List<Vector2f> computeOffsets(BlockAppearance blockAppearance, float scale) {
+    private List<org.joml.Vector2f> computeOffsets(BlockAppearance blockAppearance, float scale) {
         final float relativeTileSize = worldAtlas.getRelativeTileSize();
         final int absoluteTileSize = worldAtlas.getTileSize();
         final float pixelSize = relativeTileSize / absoluteTileSize;
@@ -197,7 +198,7 @@ public class BlockDamageAuthoritySystem extends BaseComponentSystem {
 
         return baseOffsets.flatMap(baseOffset ->
                     IntStream.range(0, 8).boxed().map(i ->
-                        new Vector2f(baseOffset).add(random.nextInt(absoluteTileSize - spriteWidth) * pixelSize, random.nextInt(absoluteTileSize - spriteWidth) * pixelSize)
+                        new org.joml.Vector2f(JomlUtil.from(baseOffset)).add(random.nextInt(absoluteTileSize - spriteWidth) * pixelSize, random.nextInt(absoluteTileSize - spriteWidth) * pixelSize)
                     )
                 ).collect(Collectors.toList());
     }

--- a/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
@@ -1,0 +1,35 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.logic.health;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.health.event.ChangeMaxHealthEvent;
+import org.terasology.logic.health.event.OnMaxHealthChangedEvent;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.widgets.UIIconBar;
+
+@RegisterSystem(value = RegisterMode.AUTHORITY)
+public class HealthAuthoritySystem extends BaseComponentSystem {
+    @In
+    NUIManager nuiManager;
+
+    @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL)
+    public void changeMaxHealth(ChangeMaxHealthEvent event, EntityRef player, HealthComponent health) {
+        player.send(new OnMaxHealthChangedEvent(health.maxHealth, (int) event.getResultValue()));
+        health.maxHealth = (int) event.getResultValue();
+        player.saveComponent(health);
+    }
+
+    @ReceiveEvent
+    public void onMaxHealthChanged(OnMaxHealthChangedEvent event, EntityRef player) {
+        UIIconBar healthBar = nuiManager.getHUD().find("healthBar", UIIconBar.class);
+        healthBar.setMaxIcons(event.getNewValue() / 10);
+    }
+}

--- a/src/main/java/org/terasology/logic/health/event/ChangeMaxHealthEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/ChangeMaxHealthEvent.java
@@ -1,0 +1,15 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.logic.health.event;
+
+import org.terasology.entitySystem.event.AbstractValueModifiableEvent;
+
+/**
+ * This Event is sent out whenever a system wants to alter the maxHealth of an entity.
+ */
+public class ChangeMaxHealthEvent extends AbstractValueModifiableEvent {
+    public ChangeMaxHealthEvent(float baseValue) {
+        super(baseValue);
+    }
+}

--- a/src/main/java/org/terasology/logic/health/event/OnMaxHealthChangedEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/OnMaxHealthChangedEvent.java
@@ -1,0 +1,49 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.logic.health.event;
+
+import org.terasology.entitySystem.event.Event;
+
+public class OnMaxHealthChangedEvent implements Event {
+    private final int newValue;
+    private final int oldValue;
+
+    /**
+     * Create a new notification event on character scaling.
+     *
+     * @param oldValue the entity's old height
+     * @param newValue the entity's new height (must be greater zero)
+     */
+    public OnMaxHealthChangedEvent(final int oldValue, final int newValue) {
+        if (newValue <= 0) {
+            throw new IllegalArgumentException("zero or negative value");
+        }
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+    }
+
+    /**
+     * The old max Health previous to scaling.
+     */
+    public int getOldValue() {
+        return oldValue;
+    }
+
+    /**
+     * The new max Health after scaling.
+     */
+    public int getNewValue() {
+        return newValue;
+    }
+
+    /**
+     * The scaling factor determined by the quotient of new and old value.
+     * <p>
+     * This is guaranteed to be greater zero (> 0).
+     */
+    public float getFactor() {
+        return (float) newValue / oldValue;
+    }
+}
+

--- a/src/main/java/org/terasology/logic/health/event/OnMaxHealthChangedEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/OnMaxHealthChangedEvent.java
@@ -11,9 +11,9 @@ public class OnMaxHealthChangedEvent implements Event {
 
     /**
      * Create a new notification event on character scaling.
-     *
-     * @param oldValue the entity's old height
-     * @param newValue the entity's new height (must be greater zero)
+     * 
+     * @param oldValue the entity's old maxHealth.
+     * @param newValue the entity's new maxHealth. (must be greater zero)
      */
     public OnMaxHealthChangedEvent(final int oldValue, final int newValue) {
         if (newValue <= 0) {

--- a/src/test/java/org/terasology/logic/health/BlockTest.java
+++ b/src/test/java/org/terasology/logic/health/BlockTest.java
@@ -77,8 +77,8 @@ public class BlockTest extends ModuleTestingEnvironment {
         assertTrue(testBlockEntity.hasComponent(BlockDamagedComponent.class));
         assertTrue(testBlockEntity.hasComponent(RegenComponent.class));
 
-        // Time for regen is 1 sec, 0.2 sec for processing buffer time
-        float regenTime = time.getGameTime() + 1 + 0.200f;
+        // Time for regen is 1 sec, 0.5 sec for processing buffer time
+        float regenTime = time.getGameTime() + 1 + 0.500f;
         runWhile(()-> time.getGameTime() <= regenTime);
 
         // On regen, health is fully restored, and BlockDamagedComponent is removed from the block

--- a/src/test/java/org/terasology/logic/health/RegenSoloTest.java
+++ b/src/test/java/org/terasology/logic/health/RegenSoloTest.java
@@ -62,8 +62,8 @@ public class RegenSoloTest extends ModuleTestingEnvironment {
         player.send(new DoDamageEvent(5));
         assertEquals(healthComponent.currentHealth, 95);
 
-        // 1 sec wait before regen, 5 secs for regen, 0.2 sec for padding.
-        float tick = time.getGameTime() + 6 + 0.200f;
+        // 1 sec wait before regen, 5 secs for regen, 0.5 sec for processing buffer time.
+        float tick = time.getGameTime() + 6 + 0.500f;
         runWhile(() -> time.getGameTime() <= tick);
 
         assertEquals(healthComponent.currentHealth, 100);

--- a/src/test/java/org/terasology/logic/health/RegenTest.java
+++ b/src/test/java/org/terasology/logic/health/RegenTest.java
@@ -91,7 +91,7 @@ public class RegenTest extends ModuleTestingEnvironment {
         RegenAuthoritySystem system = new RegenAuthoritySystem();
         assertEquals(7, system.getRegenValue(regen));
 
-        float tick = time.getGameTime() + 6 + 0.200f;
+        float tick = time.getGameTime() + 6 + 0.500f;
         runWhile(()-> time.getGameTime() <= tick);
 
         regen = player.getComponent(RegenComponent.class);


### PR DESCRIPTION
I noticed in #48 that some MTE tests are failing. This seems be to caused by some timeouts being to low (0.2 seconds for extra processing). This PR increases the extra time to 0.5 seconds - tests are succeeding locally for me.