### PR TITLE
fix: regeneration starting too soon

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "Health",
-    "version" : "1.0.2",
+    "version" : "1.1.0",
     "isReleaseManaged": true,
     "author" : "The Terasology Foundation",
     "displayName" : "Health",

--- a/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
@@ -1,20 +1,9 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.logic.health;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.audio.StaticSound;
 import org.terasology.audio.events.PlaySoundEvent;
 import org.terasology.audio.events.PlaySoundForOwnerEvent;
@@ -32,9 +21,12 @@ import org.terasology.logic.characters.MovementMode;
 import org.terasology.logic.characters.events.AttackEvent;
 import org.terasology.logic.characters.events.HorizontalCollisionEvent;
 import org.terasology.logic.characters.events.VerticalCollisionEvent;
+import org.terasology.logic.delay.DelayManager;
+import org.terasology.logic.delay.DelayedActionTriggeredEvent;
 import org.terasology.logic.health.event.ActivateRegenEvent;
 import org.terasology.logic.health.event.BeforeDamagedEvent;
 import org.terasology.logic.health.event.DamageSoundComponent;
+import org.terasology.logic.health.event.DeactivateRegenEvent;
 import org.terasology.logic.health.event.DoDamageEvent;
 import org.terasology.logic.health.event.DoRestoreEvent;
 import org.terasology.logic.health.event.OnDamagedEvent;
@@ -50,25 +42,35 @@ import org.terasology.utilities.random.Random;
  * horizontal and vertical crashes of entities with HealthComponents.
  * <p>
  * Logic flow for damage:
- * - OnDamageEvent
- * - BeforeDamageEvent
- * - (HealthComponent saved)
- * - OnDamagedEvent
- * - DestroyEvent (if no health)
+ * <ul>
+ *     <li>{@link DoDamageEvent}</li>
+ *     <li>{@link BeforeDamagedEvent}</li>
+ *     <li>{@link HealthComponent} is saved</li>
+ *     <li>{@link OnDamagedEvent}</li>
+ *     <li>{@link DestroyEvent} (if reaching 0 health)</li>
+ * </ul>
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class DamageAuthoritySystem extends BaseComponentSystem {
 
+    private static final Logger logger = LoggerFactory.getLogger(DamageAuthoritySystem.class);
+
+    private static final String DELAYED_REGEN_ACTIVATION = "DamageAuthoritySystem:activateRegenEvent";
+
     @In
     private Time time;
+
+    @In
+    private DelayManager delayManager;
 
     private Random random = new FastRandom();
 
 
     /**
-     * Override the default behavior for an attack, causing it damage as opposed to just destroying it or doing nothing.
+     * Override the default behavior for an attack, causing it damage as opposed to just destroying it or doing
+     * nothing.
      *
-     * @param event        Attack event sent on targetEntity.
+     * @param event Attack event sent on targetEntity.
      * @param targetEntity The entity which is attacked.
      */
     @ReceiveEvent(components = HealthComponent.class, netFilter = RegisterMode.AUTHORITY)
@@ -93,7 +95,8 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         event.consume();
     }
 
-    private void doDamage(EntityRef entity, int damageAmount, Prefab damageType, EntityRef instigator, EntityRef directCause) {
+    private void doDamage(EntityRef entity, int damageAmount, Prefab damageType, EntityRef instigator,
+                          EntityRef directCause) {
         HealthComponent health = entity.getComponent(HealthComponent.class);
         CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);
         boolean ghost = false;
@@ -103,19 +106,40 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         if ((health != null) && !ghost) {
             int cappedDamage = Math.min(health.currentHealth, damageAmount);
             health.currentHealth -= cappedDamage;
-            entity.send(new ActivateRegenEvent());
             entity.saveComponent(health);
             entity.send(new OnDamagedEvent(damageAmount, cappedDamage, damageType, instigator));
             if (health.currentHealth == 0 && health.destroyEntityOnNoHealth) {
                 entity.send(new DestroyEvent(instigator, directCause, damageType));
             }
+            scheduleRegenEvent(entity, health.waitBeforeRegen);
+        }
+    }
+
+    private void scheduleRegenEvent(EntityRef entity, float delayInSeconds) {
+        // deactivate base regen because entity was damaged
+        entity.send(new DeactivateRegenEvent());
+        // reset timer for activating the base regen on the entity
+        if (delayManager.hasDelayedAction(entity, DELAYED_REGEN_ACTIVATION)) {
+            logger.debug("Canceling previous delayed regen event");
+            delayManager.cancelDelayedAction(entity, DELAYED_REGEN_ACTIVATION);
+        }
+        long delayInMs = Math.round(delayInSeconds * 1000);
+        logger.debug("Scheduling delayed regen event with delay '{}'", delayInMs);
+        delayManager.addDelayedAction(entity, DELAYED_REGEN_ACTIVATION, delayInMs);
+    }
+
+    @ReceiveEvent
+    public void onDelayedRegenActivation(DelayedActionTriggeredEvent event, EntityRef entity, HealthComponent health) {
+        if (event.getActionId().equals(DELAYED_REGEN_ACTIVATION)) {
+            logger.debug("Sending delayed regen event");
+            entity.send(new ActivateRegenEvent(health.regenRate));
         }
     }
 
     /**
      * Handles DoDamageEvent to inflict damage to entity with HealthComponent.
      *
-     * @param event  DoDamageEvent causing the damage on the entity.
+     * @param event DoDamageEvent causing the damage on the entity.
      * @param entity The entity which is damaged.
      */
     @ReceiveEvent
@@ -123,12 +147,14 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         checkDamage(entity, event.getAmount(), event.getDamageType(), event.getInstigator(), event.getDirectCause());
     }
 
-    private void checkDamage(EntityRef entity, int amount, Prefab damageType, EntityRef instigator, EntityRef directCause) {
+    private void checkDamage(EntityRef entity, int amount, Prefab damageType, EntityRef instigator,
+                             EntityRef directCause) {
         // Ignore 0 damage
         if (amount == 0) {
             return;
         }
-        BeforeDamagedEvent beforeDamage = entity.send(new BeforeDamagedEvent(amount, damageType, instigator, directCause));
+        BeforeDamagedEvent beforeDamage = entity.send(new BeforeDamagedEvent(amount, damageType, instigator,
+                directCause));
         if (!beforeDamage.isConsumed()) {
             int damageAmount = TeraMath.floorToInt(beforeDamage.getResultValue());
             if (damageAmount > 0) {
@@ -142,8 +168,8 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
     /**
      * Handles damage sound on inflicting damage to entity.
      *
-     * @param event           OnDamagedEvent triggered when entity is damaged.
-     * @param entity          Entity which is damaged.
+     * @param event OnDamagedEvent triggered when entity is damaged.
+     * @param entity Entity which is damaged.
      * @param characterSounds Component having sound settings.
      */
     @ReceiveEvent
@@ -176,7 +202,7 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
     /**
      * Causes damage to entity when fallingDamageSpeedThreshold is breached.
      *
-     * @param event  VerticalCollisionEvent sent when falling speed threshold is crossed.
+     * @param event VerticalCollisionEvent sent when falling speed threshold is crossed.
      * @param entity The entity which is damaged due to falling.
      */
     @ReceiveEvent
@@ -189,7 +215,7 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
     /**
      * Inflicts damage to entity if horizontalDamageSpeedThreshold is breached.
      *
-     * @param event  HorizontalCollisionEvent sent when "falling horizontally".
+     * @param event HorizontalCollisionEvent sent when "falling horizontally".
      * @param entity Entity which is damaged on "horizontal fall".
      */
     @ReceiveEvent
@@ -213,13 +239,14 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
     /**
      * Plays landing sound on crashing horizontally.
      *
-     * @param event           HorizontalCollisionEvent sent when "falling horizontally".
-     * @param entity          Entity which is damaged on "horizontal fall".
+     * @param event HorizontalCollisionEvent sent when "falling horizontally".
+     * @param entity Entity which is damaged on "horizontal fall".
      * @param characterSounds For getting the sound to be played on crash.
      * @param healthComponent To play sound only when threshold speed is crossed.
      */
     @ReceiveEvent
-    public void onCrash(HorizontalCollisionEvent event, EntityRef entity, CharacterSoundComponent characterSounds, HealthComponent healthComponent) {
+    public void onCrash(HorizontalCollisionEvent event, EntityRef entity, CharacterSoundComponent characterSounds,
+                        HealthComponent healthComponent) {
         Vector3f horizVelocity = new Vector3f(event.getVelocity());
         horizVelocity.y = 0;
         float velocity = horizVelocity.length();
@@ -239,7 +266,7 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
     /**
      * Reduces the baseDamage of BeforeDamagedEvent if DamageResistComponent is added.
      *
-     * @param event  BeforeDamagedEvent sent before inflicting damage
+     * @param event BeforeDamagedEvent sent before inflicting damage
      * @param entity Entity which suffered some type of damage
      */
     @ReceiveEvent

--- a/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
@@ -131,7 +131,6 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
     @ReceiveEvent
     public void onDelayedRegenActivation(DelayedActionTriggeredEvent event, EntityRef entity, HealthComponent health) {
         if (event.getActionId().equals(DELAYED_REGEN_ACTIVATION)) {
-            logger.debug("Sending delayed regen event");
             entity.send(new ActivateRegenEvent(health.regenRate));
         }
     }

--- a/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
@@ -193,7 +193,7 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
     private void addRegenToScheduler(ActivateRegenEvent event, RegenComponent regen) {
         if (event.value != 0) {
             // handle indefinite regeneration actions
-            final long endTime = event.value < 0 ? -1 : time.getGameTimeInMs() + (long) (event.endTime * 1000);
+            final long endTime = event.endTime < 0 ? -1 : time.getGameTimeInMs() + (long) (event.endTime * 1000);
             regen.regenValue.put(event.id, event.value);
             regen.regenEndTime.put(endTime, event.id);
             if (endTime > 0) {

--- a/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
@@ -49,7 +49,7 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
     private static final int CHECK_INTERVAL = 200;
 
     /**
-     * The in-game in ms at which entities are to be regenerated again.
+     * The in-game time in ms at which entities are to be regenerated again.
      */
     private static long nextTick;
 

--- a/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
@@ -6,6 +6,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -35,9 +37,11 @@ import java.util.Map;
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateSubscriberSystem {
+
+    private static final Logger logger = LoggerFactory.getLogger(RegenAuthoritySystem.class);
+
     public static final String ALL_REGEN = "all";
     public static final String BASE_REGEN = "baseRegen";
-    public static final String WAIT = "wait";
 
     /**
      * Integer storing when to check each effect.
@@ -45,7 +49,7 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
     private static final int CHECK_INTERVAL = 200;
 
     /**
-     * Long storing when entities are to be regenerated again.
+     * The in-game in ms at which entities are to be regenerated again.
      */
     private static long nextTick;
 
@@ -67,44 +71,48 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
     @Override
     public void update(float delta) {
         final long currentTime = time.getGameTimeInMs();
-        // Execute regen schedule
         if (currentTime > nextTick) {
             invokeRegenOperations(currentTime);
             nextTick = currentTime + CHECK_INTERVAL;
         }
     }
 
+    /**
+     *
+     * @param currentWorldTime the current in-game time in ms
+     */
     private void invokeRegenOperations(long currentWorldTime) {
         // Contains all the entities with current time crossing EndTime
-        List<EntityRef> operationsToInvoke = new LinkedList<>();
+        List<EntityRef> entitiesWithExpiringRegenActions = new LinkedList<>();
         Iterator<Long> regenTimeIterator = regenSortedByTime.keySet().iterator();
-        long processedTime;
+        long endTime;
         while (regenTimeIterator.hasNext()) {
-            processedTime = regenTimeIterator.next();
-            if (processedTime == -1) {
+            endTime = regenTimeIterator.next();
+            if (endTime == -1) {
                 continue;
             }
-            if (processedTime > currentWorldTime) {
+            if (endTime > currentWorldTime) {
                 break;
             }
-            operationsToInvoke.addAll(regenSortedByTime.get(processedTime));
+            entitiesWithExpiringRegenActions.addAll(regenSortedByTime.get(endTime));
             regenTimeIterator.remove();
         }
 
         // Add new regen if present, or remove RegenComponent
-        operationsToInvoke.stream().filter(EntityRef::exists).forEach(regenEntity -> {
-            if (regenEntity.exists() && regenEntity.hasComponent(RegenComponent.class)) {
-                RegenComponent regen = regenEntity.getComponent(RegenComponent.class);
-                regenSortedByTime.remove(regen.soonestEndTime, regenEntity);
-                removeCompleted(currentWorldTime, regen);
-                if (regen.regenValue.isEmpty()) {
-                    regenEntity.removeComponent(RegenComponent.class);
-                } else {
-                    regenEntity.saveComponent(regen);
-                    regenSortedByTime.put(findSoonestEndTime(regen), regenEntity);
-                }
-            }
-        });
+        entitiesWithExpiringRegenActions.stream()
+                .filter(EntityRef::exists)
+                .filter(entityRef -> entityRef.hasComponent(RegenComponent.class))
+                .forEach(regenEntity -> {
+                    RegenComponent regen = regenEntity.getComponent(RegenComponent.class);
+                    regenSortedByTime.remove(regen.soonestEndTime, regenEntity);
+                    removeCompleted(currentWorldTime, regen);
+                    if (regen.regenValue.isEmpty()) {
+                        regenEntity.removeComponent(RegenComponent.class);
+                    } else {
+                        regenEntity.saveComponent(regen);
+                        regenSortedByTime.put(findSoonestEndTime(regen), regenEntity);
+                    }
+                });
 
         // Regenerate the entities with EndTime greater than Current time
         regenerate(currentWorldTime);
@@ -161,6 +169,8 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
     public void onRegenAdded(ActivateRegenEvent event, EntityRef entity, RegenComponent regen,
                              HealthComponent health) {
         if (event.value != 0) {
+            logger.debug("activate regen '{}' for entity {} with regen component", event.id, entity);
+
             // Remove previous scheduled regen, new will be added by addRegenToScheduler()
             regenSortedByTime.remove(regen.soonestEndTime, entity);
             addRegenToScheduler(event, entity, regen, health);
@@ -170,7 +180,10 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
 
     @ReceiveEvent
     public void onRegenAddedWithoutComponent(ActivateRegenEvent event, EntityRef entity, HealthComponent health) {
+        logger.debug("activate regen '{}' for entity {}", event.id, entity);
+
         if (!entity.hasComponent(RegenComponent.class)) {
+            logger.debug("creating new regen component for entity {}", entity);
             RegenComponent regen = new RegenComponent();
             regen.soonestEndTime = Long.MAX_VALUE;
             addRegenToScheduler(event, entity, regen, health);
@@ -183,8 +196,6 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
         if (event.id.equals(BASE_REGEN)) {
             // setting endTime to -1 because natural regen happens till entity fully regenerates
             addRegen(BASE_REGEN, health.regenRate, -1, regen);
-            addRegen(WAIT, -health.regenRate,
-                    time.getGameTimeInMs() + (long) (health.waitBeforeRegen * 1000), regen);
         } else {
             addRegen(event.id, event.value, time.getGameTimeInMs() + (long) (event.endTime * 1000), regen);
         }
@@ -193,6 +204,7 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
     @ReceiveEvent
     public void onRegenComponentAdded(OnActivatedComponent event, EntityRef entity, RegenComponent regen) {
         if (!regen.regenValue.isEmpty()) {
+            logger.debug("register regen component for entity {} at {}", entity, regen.soonestEndTime);
             regenSortedByTime.put(regen.soonestEndTime, entity);
         } else {
             entity.removeComponent(RegenComponent.class);
@@ -207,9 +219,6 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
             entity.removeComponent(RegenComponent.class);
         } else {
             removeRegen(event.id, regen);
-            if (event.id.equals(BASE_REGEN)) {
-                removeRegen(WAIT, regen);
-            }
             if (!regen.regenValue.isEmpty()) {
                 regenSortedByTime.put(regen.soonestEndTime, entity);
             }

--- a/src/main/java/org/terasology/logic/health/RegenComponent.java
+++ b/src/main/java/org/terasology/logic/health/RegenComponent.java
@@ -19,7 +19,7 @@ import java.util.Map;
  */
 public class RegenComponent implements Component {
     /**
-     * The timestamp in in-game time (ms) when the next regeneration action is due (or is to end?).
+     * The timestamp in in-game time (ms) when the next regeneration action ends.
      */
     @Replicate
     public long soonestEndTime = Long.MAX_VALUE;
@@ -32,9 +32,6 @@ public class RegenComponent implements Component {
 
     /**
      * Registered regeneration action ids associated to their end time(?).
-     * <p>
-     * Assumptions: - an action id can appear at multiple end times - an action id appears at most once at an end time
-     * (guaranteed by SetMultimap)
      */
     @Replicate
     public SortedSetMultimap<Long, String> regenEndTime = TreeMultimap.create(Ordering.natural(),

--- a/src/main/java/org/terasology/logic/health/RegenComponent.java
+++ b/src/main/java/org/terasology/logic/health/RegenComponent.java
@@ -31,7 +31,7 @@ public class RegenComponent implements Component {
     public Map<String, Float> regenValue = new HashMap<>();
 
     /**
-     * Registered regeneration action ids associated to their end time(?).
+     * Registered regeneration action ids associated to their end time.
      */
     @Replicate
     public SortedSetMultimap<Long, String> regenEndTime = TreeMultimap.create(Ordering.natural(),

--- a/src/main/java/org/terasology/logic/health/RegenComponent.java
+++ b/src/main/java/org/terasology/logic/health/RegenComponent.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.logic.health;
 
 import com.google.common.collect.Ordering;
@@ -24,16 +11,35 @@ import org.terasology.network.Replicate;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.terasology.logic.health.RegenAuthoritySystem.BASE_REGEN;
-
+/**
+ * Not for direct access! Use regen events instead.
+ *
+ * @see org.terasology.logic.health.event.ActivateRegenEvent
+ * @see org.terasology.logic.health.event.DeactivateRegenEvent
+ */
 public class RegenComponent implements Component {
+    /**
+     * The timestamp in in-game time (ms) when the next regeneration action is due (or is to end?).
+     */
     @Replicate
     public long soonestEndTime = Long.MAX_VALUE;
+
+    /**
+     * Mapping from regeneration action ids to the regeneration value.
+     */
     @Replicate
     public Map<String, Float> regenValue = new HashMap<>();
+
+    /**
+     * Registered regeneration action ids associated to their end time(?).
+     * <p>
+     * Assumptions: - an action id can appear at multiple end times - an action id appears at most once at an end time
+     * (guaranteed by SetMultimap)
+     */
     @Replicate
     public SortedSetMultimap<Long, String> regenEndTime = TreeMultimap.create(Ordering.natural(),
             Ordering.arbitrary());
+
     @Replicate
     public float remainder;
 }

--- a/src/main/java/org/terasology/logic/health/event/ActivateRegenEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/ActivateRegenEvent.java
@@ -37,13 +37,12 @@ public class ActivateRegenEvent implements Event {
      * Active base regeneration for the target entity.
      * <p>
      * Base regeneration (or "natural regeneration") is active until the entity is back at full health. The regeneration
-     * value is defined by {@link org.terasology.logic.health.HealthComponent#regenRate}.
+     * value is typically derived from {@link org.terasology.logic.health.HealthComponent#regenRate}.
      */
-    public ActivateRegenEvent() {
-        id = BASE_REGEN;
-        //TODO(skaldarnar): Why do we explicitly set the end time to 0 but don't set the value? The regeneration system
-        //                  will replace this value by -1 to model indefinite duration.
-        endTime = 0;
+    public ActivateRegenEvent(float value) {
+        this.value = value;
+        this.id = BASE_REGEN;
+        this.endTime = -1;
     }
 
     /**


### PR DESCRIPTION
The regeneration logic for blocks was broken such that the regeneration would start already while the block was still actively damaged.
These changes will put a delay via the DelayManager for activating the regeneration.

This introduces a breaking change to ActivateRegenEvent which now requires the regen value to be specified also for the base regen.