### PR TITLE
feat: Add damaged received overlay

### DIFF
--- a/assets/prefabs/damageTypes/maxHealthReductionDamage.prefab
+++ b/assets/prefabs/damageTypes/maxHealthReductionDamage.prefab
@@ -1,0 +1,5 @@
+{
+    "DisplayName": {
+        "name": "MaxHealthReduction"
+    }
+}

--- a/assets/skins/damagedDefault.skin
+++ b/assets/skins/damagedDefault.skin
@@ -1,0 +1,12 @@
+{
+    "inherit": "default",
+    "elements": {
+        "UIScreenLayer": {
+            "background-scale-mode": "stretch",
+            "background": "reddenedBackground"
+        },
+        "UILabel": {
+            "font": "NotoSans-Regular-Title"
+        }
+    }
+}

--- a/assets/ui/hud/damagedOverlay.ui
+++ b/assets/ui/hud/damagedOverlay.ui
@@ -1,0 +1,8 @@
+{
+    "type": "DamagedOverlay",
+    "skin": "damagedDefault",
+    "contents": {
+        "type": "relativeLayout",
+        "contents": []
+    }
+}

--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "Health",
-    "version" : "1.0.1",
+    "version" : "1.0.2",
     "isReleaseManaged": true,
     "author" : "The Terasology Foundation",
     "displayName" : "Health",

--- a/module.txt
+++ b/module.txt
@@ -6,7 +6,7 @@
     "displayName" : "Health",
     "description" : "This module provides basic implementation of Health",
     "dependencies" : [
-        { "id": "ModuleTestingEnvironment", "minVersion": "0.1.0", "optional":true },
+        { "id": "ModuleTestingEnvironment", "minVersion": "0.2.0", "optional": true },
         { "id": "CoreAssets", "minVersion": "2.0.1" }
     ],
     "serverSideOnly" : false,

--- a/src/main/java/org/terasology/logic/health/BlockDamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/BlockDamageAuthoritySystem.java
@@ -30,6 +30,7 @@ import org.terasology.logic.health.event.BeforeDamagedEvent;
 import org.terasology.logic.health.event.OnDamagedEvent;
 import org.terasology.logic.health.event.OnFullyHealedEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
@@ -170,7 +171,7 @@ public class BlockDamageAuthoritySystem extends BaseComponentSystem {
             spriteComponent.texture = terrainTexture.get();
             spriteComponent.textureSize.set(spriteSize, spriteSize);
 
-            final List<Vector2f> offsets = computeOffsets(blockAppearance, particleScale);
+            final List<org.joml.Vector2f> offsets = computeOffsets(blockAppearance, particleScale);
 
             TextureOffsetGeneratorComponent textureOffsetGeneratorComponent = builder.getComponent(TextureOffsetGeneratorComponent.class);
             textureOffsetGeneratorComponent.validOffsets.addAll(offsets);
@@ -187,7 +188,7 @@ public class BlockDamageAuthoritySystem extends BaseComponentSystem {
      *
      * @return a list of random offsets sampled from all block parts
      */
-    private List<Vector2f> computeOffsets(BlockAppearance blockAppearance, float scale) {
+    private List<org.joml.Vector2f> computeOffsets(BlockAppearance blockAppearance, float scale) {
         final float relativeTileSize = worldAtlas.getRelativeTileSize();
         final int absoluteTileSize = worldAtlas.getTileSize();
         final float pixelSize = relativeTileSize / absoluteTileSize;
@@ -197,7 +198,7 @@ public class BlockDamageAuthoritySystem extends BaseComponentSystem {
 
         return baseOffsets.flatMap(baseOffset ->
                     IntStream.range(0, 8).boxed().map(i ->
-                        new Vector2f(baseOffset).add(random.nextInt(absoluteTileSize - spriteWidth) * pixelSize, random.nextInt(absoluteTileSize - spriteWidth) * pixelSize)
+                        new org.joml.Vector2f(JomlUtil.from(baseOffset)).add(random.nextInt(absoluteTileSize - spriteWidth) * pixelSize, random.nextInt(absoluteTileSize - spriteWidth) * pixelSize)
                     )
                 ).collect(Collectors.toList());
     }

--- a/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
@@ -14,9 +14,9 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.health.event.ChangeMaxHealthEvent;
 import org.terasology.logic.health.event.DoDamageEvent;
 import org.terasology.logic.health.event.MaxHealthChangedEvent;
+import org.terasology.nui.widgets.UIIconBar;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
-import org.terasology.rendering.nui.widgets.UIIconBar;
 
 @RegisterSystem(value = RegisterMode.AUTHORITY)
 public class HealthAuthoritySystem extends BaseComponentSystem {
@@ -40,8 +40,8 @@ public class HealthAuthoritySystem extends BaseComponentSystem {
     }
 
     /**
-     * Reacts to the {@link MaxHealthChangedEvent} notification event.
-     * Is responsible for the change in maximum number of icons in the Health Bar UI.
+     * Reacts to the {@link MaxHealthChangedEvent} notification event. Is responsible for the change in maximum number
+     * of icons in the Health Bar UI.
      */
     @ReceiveEvent
     public void onMaxHealthChanged(MaxHealthChangedEvent event, EntityRef player) {

--- a/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
@@ -6,11 +6,14 @@ package org.terasology.logic.health;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.health.event.ChangeMaxHealthEvent;
-import org.terasology.logic.health.event.OnMaxHealthChangedEvent;
+import org.terasology.logic.health.event.DoDamageEvent;
+import org.terasology.logic.health.event.MaxHealthChangedEvent;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.widgets.UIIconBar;
@@ -19,16 +22,29 @@ import org.terasology.rendering.nui.widgets.UIIconBar;
 public class HealthAuthoritySystem extends BaseComponentSystem {
     @In
     NUIManager nuiManager;
+    @In
+    PrefabManager prefabManager;
 
+    /**
+     * Sends out an immutable notification event when maxHealth of a character is changed.
+     */
     @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL)
     public void changeMaxHealth(ChangeMaxHealthEvent event, EntityRef player, HealthComponent health) {
-        player.send(new OnMaxHealthChangedEvent(health.maxHealth, (int) event.getResultValue()));
+        int oldMaxHealth = health.maxHealth;
         health.maxHealth = (int) event.getResultValue();
+        Prefab maxHealthReductionDamagePrefab = prefabManager.getPrefab("Health:maxHealthReductionDamage");
+        player.send(new DoDamageEvent(Math.max(health.currentHealth - health.maxHealth, 0),
+                maxHealthReductionDamagePrefab));
+        player.send(new MaxHealthChangedEvent(oldMaxHealth, health.maxHealth));
         player.saveComponent(health);
     }
 
+    /**
+     * Reacts to the {@link MaxHealthChangedEvent} notification event.
+     * Is responsible for the change in maximum number of icons in the Health Bar UI.
+     */
     @ReceiveEvent
-    public void onMaxHealthChanged(OnMaxHealthChangedEvent event, EntityRef player) {
+    public void onMaxHealthChanged(MaxHealthChangedEvent event, EntityRef player) {
         UIIconBar healthBar = nuiManager.getHUD().find("healthBar", UIIconBar.class);
         healthBar.setMaxIcons(event.getNewValue() / 10);
     }

--- a/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
@@ -1,0 +1,35 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.logic.health;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.health.event.ChangeMaxHealthEvent;
+import org.terasology.logic.health.event.OnMaxHealthChangedEvent;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.widgets.UIIconBar;
+
+@RegisterSystem(value = RegisterMode.AUTHORITY)
+public class HealthAuthoritySystem extends BaseComponentSystem {
+    @In
+    NUIManager nuiManager;
+
+    @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL)
+    public void changeMaxHealth(ChangeMaxHealthEvent event, EntityRef player, HealthComponent health) {
+        player.send(new OnMaxHealthChangedEvent(health.maxHealth, (int) event.getResultValue()));
+        health.maxHealth = (int) event.getResultValue();
+        player.saveComponent(health);
+    }
+
+    @ReceiveEvent
+    public void onMaxHealthChanged(OnMaxHealthChangedEvent event, EntityRef player) {
+        UIIconBar healthBar = nuiManager.getHUD().find("healthBar", UIIconBar.class);
+        healthBar.setMaxIcons(event.getNewValue() / 10);
+    }
+}

--- a/src/main/java/org/terasology/logic/health/HealthClientSystem.java
+++ b/src/main/java/org/terasology/logic/health/HealthClientSystem.java
@@ -15,20 +15,54 @@
  */
 package org.terasology.logic.health;
 
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.delay.DelayManager;
+import org.terasology.logic.delay.DelayedActionTriggeredEvent;
+import org.terasology.logic.health.event.OnDamagedEvent;
+import org.terasology.logic.players.PlayerCharacterComponent;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.layers.hud.DamagedOverlay;
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class HealthClientSystem extends BaseComponentSystem {
 
+    private static final String REMOVE_DAMAGED_OVERLAY_ACTION = "Health:RemoveDamagedOverlay";
+    private static final String DAMAGED_OVERLAY = "damagedOverlay";
+    private static final long DAMAGED_OVERLAY_DELAY_MS = 150L;
+
     @In
     private NUIManager nuiManager;
+
+    @In
+    private DelayManager delayManager;
+
+    private boolean overlayDisplaying = false;
 
     @Override
     public void initialise() {
         nuiManager.getHUD().addHUDElement("healthHud");
     }
+
+    @ReceiveEvent(components = PlayerCharacterComponent.class)
+    public void onDamaged(OnDamagedEvent event, EntityRef entity) {
+        if (!overlayDisplaying && event.getDamageAmount() > 0) {
+            overlayDisplaying = true;
+            nuiManager.addOverlay(DAMAGED_OVERLAY, DamagedOverlay.class);
+            delayManager.addDelayedAction(entity, REMOVE_DAMAGED_OVERLAY_ACTION, DAMAGED_OVERLAY_DELAY_MS);
+        }
+    }
+
+    @ReceiveEvent
+    public void onDelayedAction(DelayedActionTriggeredEvent event, EntityRef entityRef) {
+        if (event.getActionId().equals(REMOVE_DAMAGED_OVERLAY_ACTION)) {
+            nuiManager.removeOverlay(DAMAGED_OVERLAY);
+            overlayDisplaying = false;
+        }
+    }
+
 }

--- a/src/main/java/org/terasology/logic/health/HealthComponent.java
+++ b/src/main/java/org/terasology/logic/health/HealthComponent.java
@@ -17,7 +17,7 @@ package org.terasology.logic.health;
 
 import org.terasology.entitySystem.Component;
 import org.terasology.network.Replicate;
-import org.terasology.rendering.nui.properties.TextField;
+import org.terasology.nui.properties.TextField;
 
 /**
  * Provides Health to entity attached with HealthComponent. Contains the parameters

--- a/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/RegenAuthoritySystem.java
@@ -1,26 +1,11 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.logic.health;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -44,6 +29,9 @@ import java.util.Map;
 
 /**
  * This system handles the natural regeneration of entities with HealthComponent.
+ * <p>
+ * Regeneration is applied once every second (every 1000ms) per {@link RegenComponent}. The active components are
+ * checked five times per second (every 200ms) whether they are due for application.
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateSubscriberSystem {
@@ -162,7 +150,7 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
                 break;
             }
         }
-        for (String id: toBeRemoved) {
+        for (String id : toBeRemoved) {
             regen.regenValue.remove(id);
         }
         regen.soonestEndTime = findSoonestEndTime(regen);

--- a/src/main/java/org/terasology/logic/health/event/ActivateRegenEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/ActivateRegenEvent.java
@@ -1,34 +1,75 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.logic.health.event;
 
 import org.terasology.entitySystem.event.Event;
 
 import static org.terasology.logic.health.RegenAuthoritySystem.BASE_REGEN;
 
+/**
+ * Send this event to active regeneration of health points for an entity.
+ * <p>
+ * The targeted entity must have a {@link org.terasology.logic.health.HealthComponent} for this event to have an
+ * effect.
+ * <p>
+ * The {@link org.terasology.logic.health.RegenAuthoritySystem} manages regeneration effects and updates affected
+ * components every "tick". A tick currently occurs once per second.
+ *
+ * @see org.terasology.logic.health.RegenAuthoritySystem
+ * @see org.terasology.logic.health.RegenComponent
+ * @see org.terasology.logic.health.HealthComponent
+ */
 public class ActivateRegenEvent implements Event {
+    /**
+     * Identifier for the cause of this regeneration effect activation.
+     */
     public String id;
+    /**
+     * Amount of additional health points per tick.
+     */
     public float value;
+    /**
+     * Effect duration in seconds.
+     */
     public float endTime;
 
+    /**
+     * Active base regeneration for the target entity.
+     * <p>
+     * Base regeneration (or "natural regeneration") is active until the entity is back at full health. The regeneration
+     * value is defined by {@link org.terasology.logic.health.HealthComponent#regenRate}.
+     */
     public ActivateRegenEvent() {
         id = BASE_REGEN;
+        //TODO(skaldarnar): Why do we explicitly set the end time to 0 but don't set the value? The regeneration system
+        //                  will replace this value by -1 to model indefinite duration.
         endTime = 0;
     }
 
+    /**
+     * Activate additional regeneration for the target entity.
+     * <p>
+     * The {@code id} is intended to uniquely identify the reason for this regeneration effect. For instance, it can
+     * denote that regeneration was trigger by a potion, caused by a spell, or any other condition.
+     * <p>
+     * The {@code value} denotes the additional amount of health points regenerated with each regeneration tick while
+     * this effect is active.
+     * <p>
+     * The {@code endTime} denotes after how many seconds the regeneration effect phases out. Once the time span is
+     * passed the effect will be removed from the entity.
+     * <p>
+     * For instance, the following constructor call could belong to a small healing potion which restores 8 health
+     * points every second over a duration of 5 seconds (e.g., healing 40 health points).
+     * <pre>
+     * {@code
+     * new ActivateRegenEvent("potions:smallHealingPotion", 8, 5);
+     * }
+     * </pre>
+     *
+     * @param id identifier for the cause of this effect
+     * @param value additional health generation amount per tick
+     * @param endTime the effect duration in seconds
+     */
     public ActivateRegenEvent(String id, float value, float endTime) {
         this.id = id;
         this.value = value;

--- a/src/main/java/org/terasology/logic/health/event/ChangeMaxHealthEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/ChangeMaxHealthEvent.java
@@ -1,0 +1,15 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.logic.health.event;
+
+import org.terasology.entitySystem.event.AbstractValueModifiableEvent;
+
+/**
+ * This Event is sent out whenever a system wants to alter the maxHealth of an entity.
+ */
+public class ChangeMaxHealthEvent extends AbstractValueModifiableEvent {
+    public ChangeMaxHealthEvent(float baseValue) {
+        super(baseValue);
+    }
+}

--- a/src/main/java/org/terasology/logic/health/event/MaxHealthChangedEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/MaxHealthChangedEvent.java
@@ -5,17 +5,17 @@ package org.terasology.logic.health.event;
 
 import org.terasology.entitySystem.event.Event;
 
-public class OnMaxHealthChangedEvent implements Event {
+public class MaxHealthChangedEvent implements Event {
     private final int newValue;
     private final int oldValue;
 
     /**
-     * Create a new notification event on character scaling.
-     * 
+     * Create a new notification event on character maxHealth scaling.
+     *
      * @param oldValue the entity's old maxHealth.
      * @param newValue the entity's new maxHealth. (must be greater zero)
      */
-    public OnMaxHealthChangedEvent(final int oldValue, final int newValue) {
+    public MaxHealthChangedEvent(final int oldValue, final int newValue) {
         if (newValue <= 0) {
             throw new IllegalArgumentException("zero or negative value");
         }

--- a/src/main/java/org/terasology/logic/health/event/OnMaxHealthChangedEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/OnMaxHealthChangedEvent.java
@@ -1,0 +1,49 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.logic.health.event;
+
+import org.terasology.entitySystem.event.Event;
+
+public class OnMaxHealthChangedEvent implements Event {
+    private final int newValue;
+    private final int oldValue;
+
+    /**
+     * Create a new notification event on character scaling.
+     *
+     * @param oldValue the entity's old height
+     * @param newValue the entity's new height (must be greater zero)
+     */
+    public OnMaxHealthChangedEvent(final int oldValue, final int newValue) {
+        if (newValue <= 0) {
+            throw new IllegalArgumentException("zero or negative value");
+        }
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+    }
+
+    /**
+     * The old max Health previous to scaling.
+     */
+    public int getOldValue() {
+        return oldValue;
+    }
+
+    /**
+     * The new max Health after scaling.
+     */
+    public int getNewValue() {
+        return newValue;
+    }
+
+    /**
+     * The scaling factor determined by the quotient of new and old value.
+     * <p>
+     * This is guaranteed to be greater zero (> 0).
+     */
+    public float getFactor() {
+        return (float) newValue / oldValue;
+    }
+}
+

--- a/src/main/java/org/terasology/logic/health/event/OnMaxHealthChangedEvent.java
+++ b/src/main/java/org/terasology/logic/health/event/OnMaxHealthChangedEvent.java
@@ -11,9 +11,9 @@ public class OnMaxHealthChangedEvent implements Event {
 
     /**
      * Create a new notification event on character scaling.
-     *
-     * @param oldValue the entity's old height
-     * @param newValue the entity's new height (must be greater zero)
+     * 
+     * @param oldValue the entity's old maxHealth.
+     * @param newValue the entity's new maxHealth. (must be greater zero)
      */
     public OnMaxHealthChangedEvent(final int oldValue, final int newValue) {
         if (newValue <= 0) {

--- a/src/main/java/org/terasology/rendering/nui/layers/hud/DamagedOverlay.java
+++ b/src/main/java/org/terasology/rendering/nui/layers/hud/DamagedOverlay.java
@@ -1,0 +1,11 @@
+package org.terasology.rendering.nui.layers.hud;
+
+import org.terasology.rendering.nui.CoreScreenLayer;
+
+public class DamagedOverlay extends CoreScreenLayer {
+
+    @Override
+    public void initialise() {
+
+    }
+}

--- a/src/main/java/org/terasology/rendering/nui/layers/hud/HealthHud.java
+++ b/src/main/java/org/terasology/rendering/nui/layers/hud/HealthHud.java
@@ -17,9 +17,9 @@ package org.terasology.rendering.nui.layers.hud;
 
 import org.terasology.logic.health.HealthComponent;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.nui.databinding.ReadOnlyBinding;
+import org.terasology.nui.widgets.UIIconBar;
 import org.terasology.registry.In;
-import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
-import org.terasology.rendering.nui.widgets.UIIconBar;
 
 public class HealthHud extends CoreHudWidget {
 


### PR DESCRIPTION
### What this PR does
Adds a red flash on the player receiving damage (the death screen background). Overlay stays for 150ms.

![image](https://user-images.githubusercontent.com/17286005/100009217-4a915d00-2e1a-11eb-8197-008e1d67a091.png)

### How to Test
Start a game with WildAnimals enabled and spawn in a hostileDeer. You should see the flash when it attacks you.