### PR TITLE
test: fix RegenTest and disable BlockTest

### DIFF
--- a/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/DamageAuthoritySystem.java
@@ -78,7 +78,7 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         damageEntity(event, targetEntity);
     }
 
-    public static void damageEntity(AttackEvent event, EntityRef targetEntity) {
+    static void damageEntity(AttackEvent event, EntityRef targetEntity) {
         int damage = 1;
         Prefab damageType = EngineDamageTypes.PHYSICAL.get();
         // Calculate damage from item
@@ -110,8 +110,9 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
             entity.send(new OnDamagedEvent(damageAmount, cappedDamage, damageType, instigator));
             if (health.currentHealth == 0 && health.destroyEntityOnNoHealth) {
                 entity.send(new DestroyEvent(instigator, directCause, damageType));
+            } else {
+                scheduleRegenEvent(entity, health.waitBeforeRegen);
             }
-            scheduleRegenEvent(entity, health.waitBeforeRegen);
         }
     }
 

--- a/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
+++ b/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
@@ -45,6 +45,8 @@ public class HealthAuthoritySystem extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void onMaxHealthChanged(MaxHealthChangedEvent event, EntityRef player) {
+        //TODO: as this is updating UI, I think this should not be in an AUTHORITY system...
+        //      this potentially requires the event to be distributed to the client (owner)
         UIIconBar healthBar = nuiManager.getHUD().find("healthBar", UIIconBar.class);
         healthBar.setMaxIcons(event.getNewValue() / 10);
     }

--- a/src/test/java/org/terasology/logic/health/BlockTest.java
+++ b/src/test/java/org/terasology/logic/health/BlockTest.java
@@ -18,6 +18,7 @@ package org.terasology.logic.health;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MTEExtension.class)
 @Dependencies({"Health"})
+@Disabled("The test has some weird timing issues which will sporadically fail it. (see #70)")
 public class BlockTest {
     private static final Vector3ic BLOCK_LOCATION = new Vector3i(0, 0, 0).add(0, -1, 0);
 
@@ -54,8 +56,7 @@ public class BlockTest {
     @In
     protected ModuleTestingHelper helper;
 
-
-    @RepeatedTest(10)
+    @Test
     public void blockRegenTest() {
         Block testBlock = blockManager.getBlock("health:test");
 

--- a/src/test/java/org/terasology/logic/health/BlockTest.java
+++ b/src/test/java/org/terasology/logic/health/BlockTest.java
@@ -18,6 +18,7 @@ package org.terasology.logic.health;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.engine.Time;
@@ -54,7 +55,7 @@ public class BlockTest {
     protected ModuleTestingHelper helper;
 
 
-    @Test
+    @RepeatedTest(10)
     public void blockRegenTest() {
         Block testBlock = blockManager.getBlock("health:test");
 

--- a/src/test/java/org/terasology/logic/health/RegenTest.java
+++ b/src/test/java/org/terasology/logic/health/RegenTest.java
@@ -33,18 +33,28 @@ public class RegenTest {
     @In
     protected ModuleTestingHelper helper;
 
-
-    @Test
-    public void regenCancelTest() {
+    EntityRef createNewPlayer(int currentHealth, int regenRate) {
         HealthComponent healthComponent = new HealthComponent();
-        healthComponent.currentHealth = 100;
+        healthComponent.currentHealth = currentHealth;
         healthComponent.maxHealth = 100;
         healthComponent.waitBeforeRegen = 1;
-        healthComponent.regenRate = 1;
+        healthComponent.regenRate = regenRate;
 
         final EntityRef player = entityManager.create();
         player.addComponent(new PlayerCharacterComponent());
         player.addComponent(healthComponent);
+
+        return player;
+    }
+
+    EntityRef createNewPlayer(int currentHealth) {
+        return createNewPlayer(currentHealth, 1);
+    }
+
+    @Test
+    public void regenCancelTest() {
+        EntityRef player = createNewPlayer(100);
+
         player.send(new DoDamageEvent(20));
 
         // Deactivate base regen
@@ -66,15 +76,7 @@ public class RegenTest {
 
     @Test
     public void multipleRegenTest() {
-        HealthComponent healthComponent = new HealthComponent();
-        healthComponent.currentHealth = 10;
-        healthComponent.maxHealth = 100;
-        healthComponent.waitBeforeRegen = 1;
-        healthComponent.regenRate = 1;
-
-        final EntityRef player = entityManager.create();
-        player.addComponent(new PlayerCharacterComponent());
-        player.addComponent(healthComponent);
+        EntityRef player = createNewPlayer(10);
 
         player.send(new ActivateRegenEvent("Potion#1", 5, 5));
         player.send(new ActivateRegenEvent("Potion#2", 2, 10));
@@ -84,7 +86,7 @@ public class RegenTest {
         assertEquals(7, system.getRegenValue(regen));
 
         float tick = time.getGameTime() + 6 + 0.200f;
-        helper.runWhile(()-> time.getGameTime() <= tick);
+        helper.runWhile(() -> time.getGameTime() <= tick);
 
         regen = player.getComponent(RegenComponent.class);
         assertEquals(2, system.getRegenValue(regen));
@@ -92,50 +94,32 @@ public class RegenTest {
 
     @Test
     public void zeroRegenTest() {
-        HealthComponent healthComponent = new HealthComponent();
-        healthComponent.currentHealth = 100;
-        healthComponent.maxHealth = 100;
-        healthComponent.waitBeforeRegen = 1;
-        healthComponent.regenRate = 0;
-
-        final EntityRef player = entityManager.create();
-        player.addComponent(new PlayerCharacterComponent());
-        player.addComponent(healthComponent);
+        EntityRef player = createNewPlayer(100, 0);
 
         player.send(new DoDamageEvent(5));
-        assertEquals(healthComponent.currentHealth, 95);
+        assertEquals(95, player.getComponent(HealthComponent.class).currentHealth);
 
         float tick = time.getGameTime() + 2 + 0.500f;
-        helper.runWhile(()-> time.getGameTime() <= tick);
+        helper.runWhile(() -> time.getGameTime() <= tick);
 
         assertFalse(player.hasComponent(RegenComponent.class));
     }
 
     @Test
     public void regenTest() {
-        HealthComponent healthComponent = new HealthComponent();
-        healthComponent.currentHealth = 100;
-        healthComponent.maxHealth = 100;
-        healthComponent.waitBeforeRegen = 1;
-        healthComponent.regenRate = 1;
-
-        final EntityRef player = entityManager.create();
-        player.addComponent(new PlayerCharacterComponent());
-        player.addComponent(healthComponent);
+        EntityRef player = createNewPlayer(100);
 
         player.send(new DoDamageEvent(5));
-        helper.runWhile(200, () -> true);
-        assertEquals(healthComponent.currentHealth, 95);
+        assertEquals(95, player.getComponent(HealthComponent.class).currentHealth);
 
-        // wait 1 second before regen starts
-        float regenStarts = time.getGameTime() + healthComponent.waitBeforeRegen + BUFFER;
-        helper.runWhile(() -> time.getGameTime() <= regenStarts);
+        // wait 1 second before regen starts (+ buffer of 200ms)
+        helper.runWhile(1200, () -> true);
         assertTrue(player.hasComponent(RegenComponent.class));
 
-        // wait for the regeneration to be finished: 5 dmg /  1hp/s = 5 seconds
+        // wait for the regeneration to be finished: 5 dmg /  1hp/s = 5 seconds (+ 200ms buffer)
         float regenEnded = time.getGameTime() + 5f + BUFFER;
-        helper.runWhile(() -> time.getGameTime() <= regenEnded);
+        helper.runWhile(5200, () -> true);
 
-        assertEquals(healthComponent.currentHealth, 100);
+        assertEquals(player.getComponent(HealthComponent.class).currentHealth, 100);
     }
 }

--- a/src/test/java/org/terasology/logic/health/RegenTest.java
+++ b/src/test/java/org/terasology/logic/health/RegenTest.java
@@ -54,8 +54,12 @@ public class RegenTest {
         int currentHealth = player.getComponent(HealthComponent.class).currentHealth;
         assertTrue(currentHealth < 100, "regeneration should have been canceled before reaching max health");
 
-        float tick = time.getGameTime() + 1 + 0.100f;
-        helper.runWhile(()-> time.getGameTime() <= tick);
+        // wait until the delay for regen is passed, and the delayed action kicks in, adding the regen component back
+        helper.runUntil(() -> player.hasComponent(RegenComponent.class));
+        player.send(new DeactivateRegenEvent());
+
+        // wait for 2 seconds to give enough time that the regeneration could have kicked in
+        helper.runWhile(2000, () -> true);
 
         assertEquals(currentHealth, player.getComponent(HealthComponent.class).currentHealth);
     }


### PR DESCRIPTION
At least locally all tests pass in one go for me now...

![image](https://user-images.githubusercontent.com/1448874/109566346-05995880-7ae4-11eb-9acd-f84095edd830.png)

### Explanation

When an entity is damaged, the immediate regeneration is paused by sending a `DeactivateRegenEvent` directly in `DamageAuthorityEvent`, and then registering a delayed regeneration event. Obviously, sending a `DeactivateRegenEvent` in the test has the same effect as what is happening anyways... To actually cancel any regeneration a system would have to react on a different event (e.g., component added or some dedicated activate regen event) and cancel/counter that.

The test is not a good test, but it at least documents the weird behavior of the system...

### Note

~~I have no idea why this fixes the test for `BlockTest.blockRegenTest()`~~ ... :roll_eyes: Okay, still fails in CI... mrgl

One way to reproduce locally is to turn that test into a `@RepeatedTest(10)` and you will most certainly run into failures.. Something for yet another PR, though.

![image](https://user-images.githubusercontent.com/1448874/109568267-f49e1680-7ae6-11eb-8160-e77cfa1983de.png)
