### PR TITLE
refactor!: improve restoration and damage event logic

### DIFF
--- a/src/main/java/org/terasology/module/health/events/DoDamageEvent.java
+++ b/src/main/java/org/terasology/module/health/events/DoDamageEvent.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.module.health.events;
 
+import com.google.common.base.Preconditions;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.event.Event;
 import org.terasology.engine.entitySystem.prefab.Prefab;
@@ -36,6 +37,7 @@ public class DoDamageEvent implements Event {
      * @param directCause       Tool used to cause the damage
      */
     public DoDamageEvent(int amount, Prefab damageType, EntityRef instigator, EntityRef directCause) {
+        Preconditions.checkArgument(amount >= 0, "damage amount must be non-negative - use DoRestorationEvent instead");
         this.amount = amount;
         this.damageType = damageType;
         this.instigator = instigator;

--- a/src/main/java/org/terasology/module/health/events/DoRestoreEvent.java
+++ b/src/main/java/org/terasology/module/health/events/DoRestoreEvent.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.module.health.events;
 
+import com.google.common.base.Preconditions;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.event.Event;
 
@@ -19,6 +20,7 @@ public class DoRestoreEvent implements Event {
     }
 
     public DoRestoreEvent(int amount, EntityRef entity) {
+        Preconditions.checkArgument(amount >= 0, "restoration amount must be non-negative - use DoDamageEvent instead");
         this.amount = amount;
         this.instigator = entity;
     }

--- a/src/main/java/org/terasology/module/health/events/MaxHealthChangedEvent.java
+++ b/src/main/java/org/terasology/module/health/events/MaxHealthChangedEvent.java
@@ -4,7 +4,9 @@
 package org.terasology.module.health.events;
 
 import org.terasology.engine.entitySystem.event.Event;
+import org.terasology.engine.network.OwnerEvent;
 
+@OwnerEvent
 public class MaxHealthChangedEvent implements Event {
     private final int newValue;
     private final int oldValue;

--- a/src/main/java/org/terasology/module/health/systems/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/module/health/systems/DamageAuthoritySystem.java
@@ -160,7 +160,7 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         BeforeDamagedEvent beforeDamage = entity.send(new BeforeDamagedEvent(amount, damageType, instigator,
                 directCause));
         if (!beforeDamage.isConsumed()) {
-            int damageAmount = TeraMath.floorToInt(beforeDamage.getResultValue());
+            int damageAmount = TeraMath.floorToInt(beforeDamage.getResultValueWithoutCapping());
             if (damageAmount > 0) {
                 doDamage(entity, damageAmount, damageType, instigator, directCause);
             } else {

--- a/src/main/java/org/terasology/module/health/systems/HealthAuthoritySystem.java
+++ b/src/main/java/org/terasology/module/health/systems/HealthAuthoritySystem.java
@@ -11,18 +11,14 @@ import org.terasology.engine.entitySystem.prefab.PrefabManager;
 import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
 import org.terasology.engine.entitySystem.systems.RegisterMode;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
+import org.terasology.engine.registry.In;
 import org.terasology.module.health.components.HealthComponent;
 import org.terasology.module.health.events.ChangeMaxHealthEvent;
 import org.terasology.module.health.events.DoDamageEvent;
 import org.terasology.module.health.events.MaxHealthChangedEvent;
-import org.terasology.nui.widgets.UIIconBar;
-import org.terasology.engine.registry.In;
-import org.terasology.engine.rendering.nui.NUIManager;
 
 @RegisterSystem(value = RegisterMode.AUTHORITY)
 public class HealthAuthoritySystem extends BaseComponentSystem {
-    @In
-    NUIManager nuiManager;
     @In
     PrefabManager prefabManager;
 
@@ -38,17 +34,5 @@ public class HealthAuthoritySystem extends BaseComponentSystem {
                 maxHealthReductionDamagePrefab));
         player.send(new MaxHealthChangedEvent(oldMaxHealth, health.maxHealth));
         player.saveComponent(health);
-    }
-
-    /**
-     * Reacts to the {@link MaxHealthChangedEvent} notification event. Is responsible for the change in maximum number
-     * of icons in the Health Bar UI.
-     */
-    @ReceiveEvent
-    public void onMaxHealthChanged(MaxHealthChangedEvent event, EntityRef player) {
-        //TODO: as this is updating UI, I think this should not be in an AUTHORITY system...
-        //      this potentially requires the event to be distributed to the client (owner)
-        UIIconBar healthBar = nuiManager.getHUD().find("healthBar", UIIconBar.class);
-        healthBar.setMaxIcons(event.getNewValue() / 10);
     }
 }

--- a/src/main/java/org/terasology/module/health/systems/HealthClientSystem.java
+++ b/src/main/java/org/terasology/module/health/systems/HealthClientSystem.java
@@ -9,14 +9,16 @@ import org.terasology.engine.entitySystem.event.ReceiveEvent;
 import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
 import org.terasology.engine.entitySystem.systems.RegisterMode;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
-import org.terasology.module.health.components.HealthComponent;
-import org.terasology.module.health.events.OnDamagedEvent;
 import org.terasology.engine.logic.location.LocationComponent;
 import org.terasology.engine.logic.players.PlayerCharacterComponent;
 import org.terasology.engine.math.Direction;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.rendering.nui.NUIManager;
+import org.terasology.module.health.components.HealthComponent;
+import org.terasology.module.health.events.MaxHealthChangedEvent;
+import org.terasology.module.health.events.OnDamagedEvent;
 import org.terasology.module.health.ui.DirectionalDamageOverlay;
+import org.terasology.nui.widgets.UIIconBar;
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class HealthClientSystem extends BaseComponentSystem {
@@ -47,10 +49,20 @@ public class HealthClientSystem extends BaseComponentSystem {
             directionalDamageOverlay.show(direction, DAMAGE_OVERLAY_DELAY_SECONDS);
         } else {
             // Show non-directional damage indication by making all four indicators visible
-            for (Direction direction: Direction.values()) {
+            for (Direction direction : Direction.values()) {
                 directionalDamageOverlay.show(direction, DAMAGE_OVERLAY_DELAY_SECONDS);
             }
         }
+    }
+
+    /**
+     * Reacts to the {@link MaxHealthChangedEvent} notification event. Is responsible for the change in maximum number
+     * of icons in the Health Bar UI.
+     */
+    @ReceiveEvent
+    public void onMaxHealthChanged(MaxHealthChangedEvent event, EntityRef player) {
+        UIIconBar healthBar = nuiManager.getHUD().find("healthBar", UIIconBar.class);
+        healthBar.setMaxIcons(event.getNewValue() / 10);
     }
 
     @VisibleForTesting

--- a/src/main/java/org/terasology/module/health/systems/RestorationAuthoritySystem.java
+++ b/src/main/java/org/terasology/module/health/systems/RestorationAuthoritySystem.java
@@ -63,16 +63,15 @@ public class RestorationAuthoritySystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void onRestoreFullHealthEvent(RestoreFullHealthEvent event, EntityRef entity, HealthComponent health) {
-        restoreFullHealth(entity, health);
+        health.currentHealth = health.maxHealth;
+        entity.saveComponent(health);
     }
 
+    //TODO: this is no logic that belongs to the API offering of this module, but a default implementation/feature.
+    //      move this to a separate system to separate concerns.
     @ReceiveEvent
     public void onRespawn(OnPlayerRespawnedEvent event, EntityRef entity, HealthComponent healthComponent) {
-        restoreFullHealth(entity, healthComponent);
+        entity.send(new RestoreFullHealthEvent(entity));
     }
 
-    private void restoreFullHealth(EntityRef entity, HealthComponent healthComponent) {
-        healthComponent.currentHealth = healthComponent.maxHealth;
-        entity.saveComponent(healthComponent);
-    }
 }

--- a/src/main/java/org/terasology/module/health/systems/RestorationAuthoritySystem.java
+++ b/src/main/java/org/terasology/module/health/systems/RestorationAuthoritySystem.java
@@ -40,7 +40,7 @@ public class RestorationAuthoritySystem extends BaseComponentSystem {
         }
         BeforeRestoreEvent beforeRestoreEvent = entity.send(new BeforeRestoreEvent(event.getAmount(), entity));
         if (!beforeRestoreEvent.isConsumed()) {
-            int modifiedRestoreAmount = TeraMath.floorToInt(beforeRestoreEvent.getResultValue());
+            int modifiedRestoreAmount = TeraMath.floorToInt(beforeRestoreEvent.getResultValueWithoutCapping());
             if (modifiedRestoreAmount > 0) {
                 restore(entity, health, modifiedRestoreAmount);
             } else {

--- a/src/test/java/org/terasology/module/health/DamageEventTest.java
+++ b/src/test/java/org/terasology/module/health/DamageEventTest.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
+import org.terasology.engine.logic.health.EngineDamageTypes;
 import org.terasology.engine.logic.players.PlayerCharacterComponent;
 import org.terasology.engine.registry.In;
 import org.terasology.module.health.components.HealthComponent;
@@ -23,6 +24,7 @@ import org.terasology.moduletestingenvironment.extension.Dependencies;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MTEExtension.class)
@@ -56,7 +58,8 @@ public class DamageEventTest {
 
     @Test
     public void damageEventSentTest() {
-        TestEventReceiver<BeforeDamagedEvent> receiver = new TestEventReceiver<>(helper.getHostContext(), BeforeDamagedEvent.class);
+        TestEventReceiver<BeforeDamagedEvent> receiver = new TestEventReceiver<>(helper.getHostContext(),
+                BeforeDamagedEvent.class);
         List<BeforeDamagedEvent> list = receiver.getEvents();
         assertTrue(list.isEmpty());
 
@@ -82,16 +85,51 @@ public class DamageEventTest {
         player.addComponent(new PlayerCharacterComponent());
         player.addComponent(healthComponent);
 
+        EntityRef dummyInstigator = entityManager.create();
+
         TestEventReceiver<BeforeDamagedEvent> receiver = new TestEventReceiver<>(helper.getHostContext(),
                 BeforeDamagedEvent.class,
                 (event, entity) -> {
-                    event.add(5);
-                    event.multiply(2);
+                    if (event.getInstigator().equals(dummyInstigator)) {
+                        event.add(5);
+                        event.multiply(2);
+                    }
                 });
+        DoDamageEvent damageEvent = new DoDamageEvent(10, EngineDamageTypes.DIRECT.get(), dummyInstigator);
+        player.send(damageEvent);
         // Expected damage value is ( initial:10 + 5 ) * 2 = 30
         // Expected health value is ( 50 - 30 ) == 20
-        player.send(new DoDamageEvent(10));
         assertEquals(20, player.getComponent(HealthComponent.class).currentHealth);
+    }
+
+    @Test
+    public void negativeDamageModifyEventTest() {
+        HealthComponent healthComponent = new HealthComponent();
+        healthComponent.currentHealth = 50;
+        healthComponent.maxHealth = 100;
+
+        final EntityRef player = entityManager.create();
+        player.addComponent(new PlayerCharacterComponent());
+        player.addComponent(healthComponent);
+
+        EntityRef dummyInstigator = entityManager.create();
+
+
+        TestEventReceiver<BeforeDamagedEvent> receiver = new TestEventReceiver<>(helper.getHostContext(),
+                BeforeDamagedEvent.class,
+                (event, entity) -> {
+                    if (event.getInstigator().equals(dummyInstigator)) {
+                        event.add(5);
+                        event.multiply(-2);
+                    }
+                });
+
+        DoDamageEvent damageEvent = new DoDamageEvent(10, EngineDamageTypes.DIRECT.get(), dummyInstigator);
+        player.send(damageEvent);
+
+        // Expected damage value is ( initial:10 + 5 ) * -2 = -30
+        // Expected health value is ( 50 - (-30) ) == 80
+        assertEquals(80, player.getComponent(HealthComponent.class).currentHealth);
     }
 
     @Test
@@ -115,18 +153,7 @@ public class DamageEventTest {
 
     @Test
     public void damageNegativeTest() {
-        HealthComponent healthComponent = new HealthComponent();
-        healthComponent.currentHealth = 50;
-        healthComponent.maxHealth = 100;
-
-        final EntityRef player = entityManager.create();
-        player.addComponent(new PlayerCharacterComponent());
-        player.addComponent(healthComponent);
-
-        player.send(new DoDamageEvent(-10));
-
-        // Negative base value are ignored by Damage system
-        assertEquals(50, player.getComponent(HealthComponent.class).currentHealth);
+        assertThrows(IllegalArgumentException.class, () -> new DoDamageEvent(-10));
     }
 
 }

--- a/src/test/java/org/terasology/module/health/DamageEventTest.java
+++ b/src/test/java/org/terasology/module/health/DamageEventTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MTEExtension.class)
-@Dependencies({"Health"})
+@Dependencies("Health")
 @Tag("MteTest")
 public class DamageEventTest {
     private static final Logger logger = LoggerFactory.getLogger(DamageEventTest.class);
@@ -38,16 +38,20 @@ public class DamageEventTest {
     @In
     protected ModuleTestingHelper helper;
 
-
-    @Test
-    public void damageTest() {
+    private EntityRef newPlayer(int currentHealth) {
         HealthComponent healthComponent = new HealthComponent();
-        healthComponent.currentHealth = 50;
+        healthComponent.currentHealth = currentHealth;
         healthComponent.maxHealth = 100;
 
         final EntityRef player = entityManager.create();
         player.addComponent(new PlayerCharacterComponent());
         player.addComponent(healthComponent);
+        return player;
+    }
+
+    @Test
+    public void damageTest() {
+        final EntityRef player = newPlayer(50);
 
         player.send(new DoDamageEvent(10));
         assertEquals(player.getComponent(HealthComponent.class).currentHealth, 40);
@@ -63,13 +67,7 @@ public class DamageEventTest {
         List<BeforeDamagedEvent> list = receiver.getEvents();
         assertTrue(list.isEmpty());
 
-        HealthComponent healthComponent = new HealthComponent();
-        healthComponent.currentHealth = 50;
-        healthComponent.maxHealth = 100;
-
-        final EntityRef player = entityManager.create();
-        player.addComponent(new PlayerCharacterComponent());
-        player.addComponent(healthComponent);
+        final EntityRef player = newPlayer(50);
 
         player.send(new DoDamageEvent(10));
         assertEquals(1, list.size());
@@ -77,13 +75,7 @@ public class DamageEventTest {
 
     @Test
     public void damageModifyEventTest() {
-        HealthComponent healthComponent = new HealthComponent();
-        healthComponent.currentHealth = 50;
-        healthComponent.maxHealth = 100;
-
-        final EntityRef player = entityManager.create();
-        player.addComponent(new PlayerCharacterComponent());
-        player.addComponent(healthComponent);
+        final EntityRef player = newPlayer(50);
 
         EntityRef dummyInstigator = entityManager.create();
 
@@ -104,13 +96,7 @@ public class DamageEventTest {
 
     @Test
     public void negativeDamageModifyEventTest() {
-        HealthComponent healthComponent = new HealthComponent();
-        healthComponent.currentHealth = 50;
-        healthComponent.maxHealth = 100;
-
-        final EntityRef player = entityManager.create();
-        player.addComponent(new PlayerCharacterComponent());
-        player.addComponent(healthComponent);
+        final EntityRef player = newPlayer(50);
 
         EntityRef dummyInstigator = entityManager.create();
 
@@ -134,13 +120,7 @@ public class DamageEventTest {
 
     @Test
     public void damageEventCancelTest() {
-        HealthComponent healthComponent = new HealthComponent();
-        healthComponent.currentHealth = 50;
-        healthComponent.maxHealth = 100;
-
-        final EntityRef player = entityManager.create();
-        player.addComponent(new PlayerCharacterComponent());
-        player.addComponent(healthComponent);
+        final EntityRef player = newPlayer(50);
 
         TestEventReceiver<BeforeDamagedEvent> receiver = new TestEventReceiver<>(helper.getHostContext(),
                 BeforeDamagedEvent.class,

--- a/src/test/java/org/terasology/module/health/RestorationTest.java
+++ b/src/test/java/org/terasology/module/health/RestorationTest.java
@@ -20,6 +20,7 @@ import org.terasology.moduletestingenvironment.extension.Dependencies;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MTEExtension.class)
@@ -98,11 +99,7 @@ public class RestorationTest {
 
     @Test
     public void restorationNegativeTest() {
-        final EntityRef player = newPlayer(50);
-
-        player.send(new DoRestoreEvent(-10));
-        // No healing happens when base restoration amount is negative, with no negative multipliers.
-        assertEquals(50, player.getComponent(HealthComponent.class).currentHealth);
+        assertThrows(IllegalArgumentException.class, () -> new DoRestoreEvent(-10));
     }
 
     @Test
@@ -114,11 +111,11 @@ public class RestorationTest {
                 (event, entity) -> {
                     event.multiply(-2);
                 })) {
-            // Expected restoration value is ( initial:10 ) * (-2) == (-20)
-            // As AbstractValueModifiableEvent#getResultValue guarantees that the resulting value is non-negative, this
-            // is actually canceled out to be 0...
             player.send(new DoRestoreEvent(10));
         }
-        assertEquals(50, player.getComponent(HealthComponent.class).currentHealth);
+        // Expected restoration value is ( initial:10 ) * (-2) == (-20)
+        // The authority system handles both cases of positive and negative restoration, and sends out an OnRestoredEvent
+        // or OnDamagedEvent, respectively. Therefore, the expected value is (initial: 50) - 20 = 30
+        assertEquals(30, player.getComponent(HealthComponent.class).currentHealth);
     }
 }


### PR DESCRIPTION
## :rocket: Features and Refactorings 

- feat!: add precondition check to DoDamage and DoRestore events to ensure non-negative amounts
- refactor: decrease coupling of default restoration logic to the authority system
- refactor: perform UI updates in client system
    
Move `onMaxHealthChanged` to HealthClientSystem, and remove NUIManager dependency from HealthAuthoritySystem.    
Tested locally with 1st client hosting the game, and 2nd client connecting.

## :bug: Fixes

- fix!: get uncapped result after collecting restoration value
- fix!: get uncapped result after collection damage amount
    
The logic in place actually handles the case where the resulting value is less than 0, but due to the used getter this code path was actually dead.
Using the uncapped getter seems more reasonable here.    

## :test_tube: Tests

- test: adjust tests for damage and restoration scenarios to changed logic
- test: remove code duplication in DamageEventTest
    
As it is no longer possible to create these events with a negative base value we now assert that attempting to do this throws an `IllegalArgumentException`.    
In addition, the behavior is different if the collection phase yields a negative change value in total. In that case, the triggered event is inverted, e.g., if a restoration yields a negative restoration amount the health system sends out an `OnDamagedEvent`.

BREAKING CHANGE: Creating `DoDamageEvent` or `DoRestoreEvent` with a negative base value will now fail with an `IllegalArgumentException`.