### PR TITLE
style: fix static analysis reports (checkstyle, spotbugs, pmd)

### DIFF
--- a/src/main/java/org/terasology/module/health/components/DamageResistComponent.java
+++ b/src/main/java/org/terasology/module/health/components/DamageResistComponent.java
@@ -3,8 +3,9 @@
 package org.terasology.module.health.components;
 
 import org.terasology.engine.entitySystem.Component;
+
 import java.util.Map;
 
 public class DamageResistComponent implements Component {
-   public Map<String,Float> damageTypes;
+    public Map<String, Float> damageTypes;
 }

--- a/src/main/java/org/terasology/module/health/core/BaseRegenAuthoritySystem.java
+++ b/src/main/java/org/terasology/module/health/core/BaseRegenAuthoritySystem.java
@@ -33,7 +33,7 @@ public class BaseRegenAuthoritySystem extends BaseComponentSystem {
      *
      * @param entity the entity with {@link BaseRegenComponent} that was created, loaded or extended with that component
      */
-    @ReceiveEvent(components = {BaseRegenComponent.class})
+    @ReceiveEvent(components = BaseRegenComponent.class)
     public void registerBaseRegen(OnActivatedComponent event, EntityRef entity) {
         entity.send(new RegisterRegenEvent(BASE_REGEN));
     }

--- a/src/main/java/org/terasology/module/health/systems/BlockDamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/module/health/systems/BlockDamageAuthoritySystem.java
@@ -6,7 +6,6 @@ import org.joml.Vector2f;
 import org.joml.Vector2fc;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
-import org.terasology.engine.audio.AudioManager;
 import org.terasology.engine.audio.StaticSound;
 import org.terasology.engine.audio.events.PlaySoundEvent;
 import org.terasology.engine.entitySystem.entity.EntityBuilder;
@@ -28,7 +27,6 @@ import org.terasology.engine.utilities.random.Random;
 import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.block.BlockAppearance;
 import org.terasology.engine.world.block.BlockComponent;
-import org.terasology.engine.world.block.BlockManager;
 import org.terasology.engine.world.block.BlockPart;
 import org.terasology.engine.world.block.entity.damage.BlockDamageModifierComponent;
 import org.terasology.engine.world.block.family.BlockFamily;
@@ -62,13 +60,8 @@ public class BlockDamageAuthoritySystem extends BaseComponentSystem {
     private EntityManager entityManager;
 
     @In
-    private AudioManager audioManager;
-
-    @In
     private WorldAtlas worldAtlas;
 
-    @In
-    private BlockManager blockManager;
 
     private Random random = new FastRandom();
 

--- a/src/main/java/org/terasology/module/health/systems/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/module/health/systems/DamageAuthoritySystem.java
@@ -3,8 +3,6 @@
 package org.terasology.module.health.systems;
 
 import org.joml.Vector3f;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.engine.audio.StaticSound;
 import org.terasology.engine.audio.events.PlaySoundEvent;
 import org.terasology.engine.audio.events.PlaySoundForOwnerEvent;

--- a/src/main/java/org/terasology/module/health/systems/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/module/health/systems/DamageAuthoritySystem.java
@@ -53,8 +53,6 @@ import org.terasology.module.health.events.OnDamagedEvent;
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class DamageAuthoritySystem extends BaseComponentSystem {
 
-    private static final Logger logger = LoggerFactory.getLogger(DamageAuthoritySystem.class);
-
     @In
     private Time time;
 
@@ -225,7 +223,7 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         float velocity = horizVelocity.length();
 
         if (velocity > healthComponent.horizontalDamageSpeedThreshold) {
-            if (characterSounds.lastSoundTime + CharacterSoundSystem.MIN_TIME < time.getGameTimeInMs()) {
+            if (characterSounds.lastSoundTime + CharacterSoundSystem.MIN_TIME < time.getGameTimeInMs()) { // NOPMD - if statements separated on purpose
                 StaticSound sound = random.nextItem(characterSounds.landingSounds);
                 if (sound != null) {
                     entity.send(new PlaySoundEvent(sound, characterSounds.landingVolume));

--- a/src/main/java/org/terasology/module/health/systems/HealthCommands.java
+++ b/src/main/java/org/terasology/module/health/systems/HealthCommands.java
@@ -118,10 +118,8 @@ public class HealthCommands extends BaseComponentSystem {
     public String checkResistance(@Sender EntityRef clientEntity) {
         ClientComponent player = clientEntity.getComponent(ClientComponent.class);
         DamageResistComponent damageResist = player.character.getComponent(DamageResistComponent.class);
-        if (damageResist != null) {
-            if (damageResist.damageTypes != null) {
-                return damageResist.damageTypes.entrySet().toString();
-            }
+        if (damageResist != null && damageResist.damageTypes != null) {
+            return damageResist.damageTypes.entrySet().toString();
         }
         return "You don't have Resistance to any type of damage.";
     }

--- a/src/main/java/org/terasology/module/health/systems/HealthCommands.java
+++ b/src/main/java/org/terasology/module/health/systems/HealthCommands.java
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.module.health.systems;
 
-import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.prefab.Prefab;
 import org.terasology.engine.entitySystem.prefab.PrefabManager;
@@ -18,10 +17,10 @@ import org.terasology.engine.network.ClientComponent;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.registry.Share;
 import org.terasology.engine.utilities.Assets;
+import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.module.health.components.DamageResistComponent;
 import org.terasology.module.health.components.HealthComponent;
 import org.terasology.module.health.core.BaseRegenComponent;
-import org.terasology.module.health.events.RegisterRegenEvent;
 import org.terasology.module.health.events.DoDamageEvent;
 import org.terasology.module.health.events.DoRestoreEvent;
 
@@ -84,12 +83,14 @@ public class HealthCommands extends BaseComponentSystem {
             if (damageType.equals("all")) {
                 damageResist.damageTypes = new HashMap<>();
                 damageResist.damageTypes.put("all", value);
-                if (value == 0)
+                if (value == 0) {
                     player.character.removeComponent(DamageResistComponent.class);
+                }
             } else {
                 if (prefabManager.exists(damageType)) {
-                    if (damageResist.damageTypes == null)
+                    if (damageResist.damageTypes == null) {
                         damageResist.damageTypes = new HashMap<>();
+                    }
                     if (value == 0) {
                         damageResist.damageTypes.remove(damageType);
                     } else {
@@ -118,8 +119,9 @@ public class HealthCommands extends BaseComponentSystem {
         ClientComponent player = clientEntity.getComponent(ClientComponent.class);
         DamageResistComponent damageResist = player.character.getComponent(DamageResistComponent.class);
         if (damageResist != null) {
-            if (damageResist.damageTypes != null)
+            if (damageResist.damageTypes != null) {
                 return damageResist.damageTypes.entrySet().toString();
+            }
         }
         return "You don't have Resistance to any type of damage.";
     }

--- a/src/main/java/org/terasology/module/health/systems/HealthCommands.java
+++ b/src/main/java/org/terasology/module/health/systems/HealthCommands.java
@@ -147,12 +147,14 @@ public class HealthCommands extends BaseComponentSystem {
     public String setMaxHealth(@Sender EntityRef client, @CommandParam("max") int max) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         HealthComponent health = clientComp.character.getComponent(HealthComponent.class);
-        float oldMaxHealth = health.maxHealth;
+
         if (health != null) {
+            float oldMaxHealth = health.maxHealth;
             health.maxHealth = max;
             clientComp.character.saveComponent(health);
+            return "Max health changed from " + oldMaxHealth + " to " + max;
         }
-        return "Max health changed from " + oldMaxHealth + " to " + max;
+        return "... nothing to do";
     }
 
     @Command(shortDescription = "Set health regen rate", runOnServer = true,

--- a/src/main/java/org/terasology/module/health/systems/RegenAuthoritySystem.java
+++ b/src/main/java/org/terasology/module/health/systems/RegenAuthoritySystem.java
@@ -14,10 +14,9 @@ import org.terasology.engine.registry.In;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.module.health.components.HealthComponent;
 import org.terasology.module.health.components.RegenComponent;
-import org.terasology.module.health.events.RegisterRegenEvent;
 import org.terasology.module.health.events.BeforeRegenEvent;
 import org.terasology.module.health.events.DeregisterRegenEvent;
-import org.terasology.module.health.time.Duration;
+import org.terasology.module.health.events.RegisterRegenEvent;
 import org.terasology.module.health.time.Instant;
 
 /**
@@ -43,7 +42,7 @@ public class RegenAuthoritySystem extends BaseComponentSystem implements UpdateS
      * This is required as the sampling rate of applying regeneration effects is usually lower than the tick rate of the
      * game.
      */
-    float regenTick = 0f;
+    float regenTick;
 
     @Override
     public void update(float delta) {

--- a/src/test/java/org/terasology/module/health/BlockTest.java
+++ b/src/test/java/org/terasology/module/health/BlockTest.java
@@ -57,7 +57,6 @@ public class BlockTest {
         EntityRef testBlockEntity = blockEntityRegistry.getExistingBlockEntityAt(BLOCK_LOCATION);
 
         // Attack on block, damage of 1 inflicted
-        float currentTime = time.getGameTime();
         testBlockEntity.send(new AttackEvent(testBlockEntity, testBlockEntity));
 
         // Make sure that the attack actually caused damage and started regen

--- a/src/test/java/org/terasology/module/health/DamageEventTest.java
+++ b/src/test/java/org/terasology/module/health/DamageEventTest.java
@@ -6,8 +6,6 @@ package org.terasology.module.health;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.logic.health.EngineDamageTypes;
@@ -31,8 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Dependencies("Health")
 @Tag("MteTest")
 public class DamageEventTest {
-    private static final Logger logger = LoggerFactory.getLogger(DamageEventTest.class);
-
     @In
     protected EntityManager entityManager;
     @In
@@ -100,7 +96,6 @@ public class DamageEventTest {
 
         EntityRef dummyInstigator = entityManager.create();
 
-
         TestEventReceiver<BeforeDamagedEvent> receiver = new TestEventReceiver<>(helper.getHostContext(),
                 BeforeDamagedEvent.class,
                 (event, entity) -> {
@@ -117,7 +112,7 @@ public class DamageEventTest {
         // Expected health value is ( 50 - (-30) ) == 80
         assertEquals(80, player.getComponent(HealthComponent.class).currentHealth);
     }
-
+    
     @Test
     public void damageEventCancelTest() {
         final EntityRef player = newPlayer(50);

--- a/src/test/java/org/terasology/module/health/systems/RegenTest.java
+++ b/src/test/java/org/terasology/module/health/systems/RegenTest.java
@@ -29,8 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag("MteTest")
 public class RegenTest {
 
-    private static final float BUFFER = 0.2f; // 200 ms buffer time
-
     @In
     protected EntityManager entityManager;
     @In
@@ -104,7 +102,6 @@ public class RegenTest {
         assertTrue(player.hasComponent(RegenComponent.class));
 
         // wait for the regeneration to be finished: 5 dmg /  1hp/s = 5 seconds (+ 200ms buffer)
-        float regenEnded = time.getGameTime() + 5f + BUFFER;
         helper.runWhile(5200, () -> true);
 
         assertEquals(player.getComponent(HealthComponent.class).currentHealth, 100);


### PR DESCRIPTION
`gradlew :modules:Health:checkstyleMain` - checkstyle integration with IntelliJ is pretty good. There's actually no need to run this manually via Gradle as IntelliJ gives the same results, and directly points to the respective locations. :+1: 

`gradlew :modules:Health:spotbugsMain` - SpotBugs with the [SpotBugs Plugin](https://plugins.jetbrains.com/plugin/14014-spotbugs) gave a mixed impression. You cannot run it directly on the module, but have to select the `src/main` source set _after_ compiling the module. However, when run via command line it shows the exception stack trace, but no link to a human readable report... nargh :roll_eyes: 

`gradlew :modules:Health:pmdMain` - Could not get this to work with IntelliJ and our configuration. When run via Gradle, I get 8 warnings which I could easily work on. IntelliJ did not find our configuration and used some default, which report 830 errors :eyes: 