### PR TITLE
fix: only send OnDamagedEvent on positive amount of damage

### DIFF
--- a/src/main/java/org/terasology/module/health/systems/DamageAuthoritySystem.java
+++ b/src/main/java/org/terasology/module/health/systems/DamageAuthoritySystem.java
@@ -96,11 +96,14 @@ public class DamageAuthoritySystem extends BaseComponentSystem {
         }
         if ((health != null) && !ghost) {
             int cappedDamage = Math.min(health.currentHealth, damageAmount);
-            health.currentHealth -= cappedDamage;
-            entity.saveComponent(health);
-            entity.send(new OnDamagedEvent(cappedDamage, damageType, instigator));
-            if (health.currentHealth == 0 && health.destroyEntityOnNoHealth) {
-                entity.send(new DestroyEvent(instigator, directCause, damageType));
+            if (cappedDamage > 0) { // ignore if no damage is dealt
+                health.currentHealth -= cappedDamage;
+                entity.saveComponent(health);
+
+                entity.send(new OnDamagedEvent(cappedDamage, damageType, instigator));
+                if (health.currentHealth == 0 && health.destroyEntityOnNoHealth) {
+                    entity.send(new DestroyEvent(instigator, directCause, damageType));
+                }
             }
         }
     }


### PR DESCRIPTION
**Problem:** It can happen that an entity is damaged which is already sitting on 0 points of health. Notify that such an entity was damaged with a total amount of zero points of damage may cause issues in other systems, e.g., in Behaviors.

**Solution:** Don't send out OnDamagedEvents if the entity did take zero points of damage.
