### PR TITLE
refactor(test): replace Dependencies annotation with IntegrationEnvironment

### DIFF
--- a/src/test/java/org/terasology/module/health/BlockTest.java
+++ b/src/test/java/org/terasology/module/health/BlockTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.engine.core.Time;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.characters.events.AttackEvent;
 import org.terasology.engine.registry.In;
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MTEExtension.class)
-@Dependencies("Health")
+@IntegrationEnvironment(dependencies = { "Health" })
 @Tag("MteTest")
 @Disabled("The test has some weird timing issues which will sporadically fail it. (see #70)")
 public class BlockTest {

--- a/src/test/java/org/terasology/module/health/BlockTest.java
+++ b/src/test/java/org/terasology/module/health/BlockTest.java
@@ -7,14 +7,11 @@ package org.terasology.module.health;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.engine.core.Time;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
 import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.characters.events.AttackEvent;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.world.BlockEntityRegistry;
@@ -27,9 +24,7 @@ import org.terasology.module.health.components.RegenComponent;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(MTEExtension.class)
 @IntegrationEnvironment(dependencies = { "Health" })
-@Tag("MteTest")
 @Disabled("The test has some weird timing issues which will sporadically fail it. (see #70)")
 public class BlockTest {
     private static final Vector3ic BLOCK_LOCATION = new Vector3i(0, 0, 0).add(0, -1, 0);

--- a/src/test/java/org/terasology/module/health/BlockTest.java
+++ b/src/test/java/org/terasology/module/health/BlockTest.java
@@ -24,7 +24,7 @@ import org.terasology.module.health.components.RegenComponent;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@IntegrationEnvironment(dependencies = { "Health" })
+@IntegrationEnvironment(dependencies = "Health")
 @Disabled("The test has some weird timing issues which will sporadically fail it. (see #70)")
 public class BlockTest {
     private static final Vector3ic BLOCK_LOCATION = new Vector3i(0, 0, 0).add(0, -1, 0);

--- a/src/test/java/org/terasology/module/health/DamageEventTest.java
+++ b/src/test/java/org/terasology/module/health/DamageEventTest.java
@@ -10,7 +10,7 @@ import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
 import org.terasology.engine.integrationenvironment.TestEventReceiver;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.health.EngineDamageTypes;
 import org.terasology.engine.logic.players.PlayerCharacterComponent;
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MTEExtension.class)
-@Dependencies("Health")
+@IntegrationEnvironment(dependencies = { "Health" })
 @Tag("MteTest")
 public class DamageEventTest {
     @In

--- a/src/test/java/org/terasology/module/health/DamageEventTest.java
+++ b/src/test/java/org/terasology/module/health/DamageEventTest.java
@@ -3,15 +3,12 @@
 
 package org.terasology.module.health;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
 import org.terasology.engine.integrationenvironment.TestEventReceiver;
 import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.health.EngineDamageTypes;
 import org.terasology.engine.logic.players.PlayerCharacterComponent;
 import org.terasology.engine.registry.In;
@@ -25,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@IntegrationEnvironment(dependencies = { "Health" })
+@IntegrationEnvironment(dependencies = "Health")
 public class DamageEventTest {
     @In
     protected EntityManager entityManager;

--- a/src/test/java/org/terasology/module/health/DamageEventTest.java
+++ b/src/test/java/org/terasology/module/health/DamageEventTest.java
@@ -25,9 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(MTEExtension.class)
 @IntegrationEnvironment(dependencies = { "Health" })
-@Tag("MteTest")
 public class DamageEventTest {
     @In
     protected EntityManager entityManager;

--- a/src/test/java/org/terasology/module/health/RestorationTest.java
+++ b/src/test/java/org/terasology/module/health/RestorationTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@IntegrationEnvironment(dependencies = { "Health" })
+@IntegrationEnvironment(dependencies = "Health")
 public class RestorationTest {
 
     @In

--- a/src/test/java/org/terasology/module/health/RestorationTest.java
+++ b/src/test/java/org/terasology/module/health/RestorationTest.java
@@ -2,15 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.module.health;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
 import org.terasology.engine.integrationenvironment.TestEventReceiver;
 import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.players.PlayerCharacterComponent;
 import org.terasology.engine.registry.In;
 import org.terasology.module.health.components.HealthComponent;
@@ -23,9 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(MTEExtension.class)
 @IntegrationEnvironment(dependencies = { "Health" })
-@Tag("MteTest")
 public class RestorationTest {
 
     @In

--- a/src/test/java/org/terasology/module/health/RestorationTest.java
+++ b/src/test/java/org/terasology/module/health/RestorationTest.java
@@ -9,7 +9,7 @@ import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
 import org.terasology.engine.integrationenvironment.TestEventReceiver;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.players.PlayerCharacterComponent;
 import org.terasology.engine.registry.In;
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MTEExtension.class)
-@Dependencies("Health")
+@IntegrationEnvironment(dependencies = { "Health" })
 @Tag("MteTest")
 public class RestorationTest {
 

--- a/src/test/java/org/terasology/module/health/systems/RegenTest.java
+++ b/src/test/java/org/terasology/module/health/systems/RegenTest.java
@@ -3,15 +3,12 @@
 
 package org.terasology.module.health.systems;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.engine.core.Time;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
 import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.players.PlayerCharacterComponent;
 import org.terasology.engine.registry.In;
 import org.terasology.module.health.components.HealthComponent;
@@ -24,9 +21,7 @@ import org.terasology.module.health.events.DoDamageEvent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(MTEExtension.class)
 @IntegrationEnvironment(dependencies = { "Health" })
-@Tag("MteTest")
 public class RegenTest {
 
     @In

--- a/src/test/java/org/terasology/module/health/systems/RegenTest.java
+++ b/src/test/java/org/terasology/module/health/systems/RegenTest.java
@@ -21,7 +21,7 @@ import org.terasology.module.health.events.DoDamageEvent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@IntegrationEnvironment(dependencies = { "Health" })
+@IntegrationEnvironment(dependencies = "Health")
 public class RegenTest {
 
     @In

--- a/src/test/java/org/terasology/module/health/systems/RegenTest.java
+++ b/src/test/java/org/terasology/module/health/systems/RegenTest.java
@@ -10,7 +10,7 @@ import org.terasology.engine.core.Time;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.players.PlayerCharacterComponent;
 import org.terasology.engine.registry.In;
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MTEExtension.class)
-@Dependencies("Health")
+@IntegrationEnvironment(dependencies = { "Health" })
 @Tag("MteTest")
 public class RegenTest {
 


### PR DESCRIPTION
This is my first contribution to an Open Source Project 🙂

I replaced the annotation ```Dependencies``` in ```BlockTest```, ```DamageEventTest```, ```RestorationTest``` and ```RegenTest``` with ```IntegrationEnvironment```. 

For more information, see <a href="https://github.com/MovingBlocks/Terasology/issues/5087">#5087</a>

